### PR TITLE
add connection to manageiq server

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+
+from manageiq_client.api import APIException, ManageIQClient
+from requests.exceptions import ConnectionError
+
+
+class ClientAPI(object):
+    """ManageIQ API client class.
+
+    Class interfaces with ManageIQ server. The underlying component performing
+    the interactions with the server is the ManageIQ Python API Client.
+
+    https://github.com/ManageIQ/manageiq-api-client-python
+
+    This library is used to establish connection to the server defined, talk
+    with all the servers collections and perform CRUD operations.
+
+    Each CLI command will reference this class to perform its collections
+    actions.
+    """
+
+    def __init__(self):
+        """Constructor."""
+        self._client = None
+
+    @property
+    def client(self):
+        """Return the ManageIQ API Client connection property.
+
+        :return: ManageIQ client connection.
+        :rtype: object
+        """
+        return self._client
+
+    @client.setter
+    def client(self, value):
+        """Set the ManageIQ client connection property.
+
+        :param value: ManageIQ API Client connection
+        :type value: object
+        """
+        self._client = value
+
+    def connect(self, settings):
+        """Create a connection to the ManageIQ server.
+
+        :param settings: ManageIQ settings.
+        :type settings: dict
+        """
+        try:
+            # TODO: handle setting auth details, covered by issue #33
+            self._client = ManageIQClient(
+                entry_point=os.path.join(settings['url'], 'api'),
+                auth=dict(
+                    user=settings['username'],
+                    password=settings['password'],
+                    token=settings['token']
+                ),
+                verify_ssl=settings['enable_ssl_verify']
+            )
+        except (APIException, ConnectionError) as ex:
+            raise RuntimeError(ex)

--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -204,6 +204,19 @@ class SubCollections(click.MultiCommand):
         cmd = click.command(name=name, **attributes)(new_method)
         return cmd
 
+    def invoke(self, ctx):
+        """Invoke the sub-command selected.
+
+        Runs the sub-command given with all its arguments. Before it invokes
+        the sub-command action to run, it will attempt to establish a
+        connection to ManageIQ.
+
+        :param ctx: Click context.
+        :type ctx: Namespace
+        """
+        self.collection.connect()
+        super(SubCollections, self).invoke(ctx)
+
 
 # set context settings w/ our configuration
 config = Config(DEFAULT_CONFIG)

--- a/miqcli/collections/__init__.py
+++ b/miqcli/collections/__init__.py
@@ -14,8 +14,10 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.api import ClientAPI
 
-class Collection(object):
+
+class Collection(ClientAPI):
     """
     Collection Class
 
@@ -29,6 +31,7 @@ class Collection(object):
         :param settings: MIQ settings
         :type settings: dict
         """
+        super(Collection, self).__init__()
         self._settings = settings
 
     @property
@@ -37,3 +40,7 @@ class Collection(object):
         :return: dict of settings
         """
         return self._settings
+
+    def connect(self):
+        """Create a connection to the ManageIQ server."""
+        super(Collection, self).connect(self.settings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 click==6.7
+manageiq-client==0.3.0
 PyYAML==3.12
+requests==2.18.4


### PR DESCRIPTION
This commit adds the ability to create an established connection to
the defined manageiq server. The connection happens on demand when the
cli command and its given options is invoked. It will never create a
connection when running the cli to view its commands/sub-commands.

This PR closes #34 