### PR TITLE
add compatibility module

### DIFF
--- a/miqcli/_compat.py
+++ b/miqcli/_compat.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Compatibility module for Python 2.x/3.x support."""
+
+try:
+    from xmlrpclib import ServerProxy
+except ImportError:
+    from xmlrpc.client import ServerProxy

--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -19,14 +19,10 @@ from copy import copy
 from functools import wraps
 from importlib import import_module
 
-try:
-    from xmlrpclib import ServerProxy
-except ImportError:
-    from xmlrpc.client import ServerProxy
-
 import click
 from os import listdir
 
+from miqcli._compat import ServerProxy
 from miqcli.constants import COLLECTIONS_PACKAGE, COLLECTIONS_ROOT, PACKAGE, \
     PYPI, VERSION, MIQCLI_CFG_FILE_LOC, DEFAULT_CONFIG, MIQCLI_CFG_NAME
 from miqcli.utils import Config, get_class_methods

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,9 @@ commands =
   python setup.py test --coverage
 
 [flake8]
+# F401 module import but unused, needed for python 2/3 compatibility
 # H904 "Wrap lines in parentheses and not a backslash for line continuation
 # Removed in current hacking (https://review.openstack.org/#/c/101701/).
-ignore = H803,H904
+ignore = F401,H803,H904
 exclude = .venv,.tox,dist,doc,*.egg,build
 show-source = true


### PR DESCRIPTION
Adds a new module to store all backwards compatibility code for
Python 2.x/3.x support.

Also ignores flake8 error code F401 (ignore unused module imports). This
is needed by the compat module since it has imports that are unused.