### PR TITLE
Adding the recommended way of authentication for ManageIQ.

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -16,8 +16,13 @@
 
 import os
 
+import requests
+from requests.auth import HTTPBasicAuth
+
 from manageiq_client.api import APIException, ManageIQClient
 from requests.exceptions import ConnectionError
+
+from miqcli.constants import AUTHDIR
 
 
 class ClientAPI(object):
@@ -63,16 +68,79 @@ class ClientAPI(object):
         :param settings: ManageIQ settings.
         :type settings: dict
         """
+        authfile = os.path.join(os.environ["HOME"], AUTHDIR)
+        # attempt a connection with a passed token
+        if "token" in settings and settings["token"]:
+            succ_auth, exception = self.miq_auth(settings["token"])
+            if not succ_auth:
+                raise RuntimeError("Unable to auth with passed token: "
+                                   "{0}".format(exception))
+        # check for an auth token file & validate
+        if os.path.isfile(authfile):
+            with file(authfile) as f:
+                settings["token"] = f.read().strip()
+            succ_auth, exception = self.miq_auth(settings["token"])
+            if not succ_auth:
+                if "username" in settings and settings["username"] and \
+                        "password" in settings and settings["password"]:
+                    self.get_token()
+                else:
+                    raise RuntimeError("Please provide valid "
+                                       "credentials to connect")
+                succ_auth, exception = self.miq_auth(settings["token"])
+                if not succ_auth:
+                    raise RuntimeError("Unable to authenticate "
+                                       "{0}".format(exception))
+        # authenticate and create auth token file if it does not exist
+        else:
+            if not os.path.exists(os.path.dirname(authfile)):
+                os.makedirs(os.path.dirname(authfile))
+
+            if "username" in settings and settings["username"] and \
+                    "password" in settings and settings["password"]:
+                self.get_token()
+            else:
+                raise RuntimeError("Provide valid credentials to connect")
+            succ_auth, exception = self.miq_auth(settings["token"])
+            if not succ_auth:
+                raise RuntimeError("Authentication failed: "
+                                   "{0}".format(exception))
+
+    def get_token(self):
+        """
+        method to get a token if username/password is set
+        """
+        auth_endpoint = self.settings["url"] + "/auth"
+        output = requests.get(auth_endpoint,
+                              auth=HTTPBasicAuth(self.settings["username"],
+                                                 self.settings["password"]),
+                              verify=False)
+
+        if output.status_code == 200:
+            self.settings["token"] = output.json()["auth_token"]
+        else:
+            raise RuntimeError("Unsuccessful attempt to authenticate: "
+                               "{}".format(output.status_code))
+
+    def miq_auth(self, token):
+        """
+        method to authenticate to the ManageIQ Server given a token
+        :param token: token to authenticate with
+        :return: tuple (successful True/False, and Exception)
+        :rtype: (Boolean, str)
+        """
+        settings = self.settings
+        authfile = os.path.join(os.environ["HOME"], AUTHDIR)
+
         try:
-            # TODO: handle setting auth details, covered by issue #33
-            self._client = ManageIQClient(
-                entry_point=os.path.join(settings['url'], 'api'),
-                auth=dict(
-                    user=settings['username'],
-                    password=settings['password'],
-                    token=settings['token']
-                ),
-                verify_ssl=settings['enable_ssl_verify']
-            )
+            self._client = ManageIQClient(settings["url"],
+                                  dict(token=settings["token"]),
+                                  verify_ssl=settings["enable_ssl_verify"])
+            # update auth file with token
+            with open(authfile, "w") as f:
+                f.write(token)
+
+            return (True, None)
         except (APIException, ConnectionError) as ex:
-            raise RuntimeError(ex)
+            # token is invalid
+            return (False, ex)

--- a/miqcli/collections/__init__.py
+++ b/miqcli/collections/__init__.py
@@ -31,16 +31,8 @@ class Collection(ClientAPI):
         :param settings: MIQ settings
         :type settings: dict
         """
-        super(Collection, self).__init__()
-        self._settings = settings
-
-    @property
-    def settings(self):
-        """
-        :return: dict of settings
-        """
-        return self._settings
+        super(Collection, self).__init__(settings)
 
     def connect(self):
         """Create a connection to the ManageIQ server."""
-        super(Collection, self).connect(self.settings)
+        super(Collection, self).connect()

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -27,6 +27,7 @@ MIQCLI_CFG_NAME = 'miqcli'
 DEFAULT_CONFIG = {
     'username': 'admin',
     'password': 'smartvm',
-    'url': 'https://localhost:8443',
+    'url': 'https://localhost:8443/api',
     'enable_ssl_verify': False
 }
+AUTHDIR = ".miqcli/auth"

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -27,7 +27,7 @@ MIQCLI_CFG_NAME = 'miqcli'
 DEFAULT_CONFIG = {
     'username': 'admin',
     'password': 'smartvm',
-    'url': 'https://localhost:8443/api',
+    'url': 'https://localhost:8443',
     'enable_ssl_verify': False
 }
 AUTHDIR = ".miqcli/auth"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
--e git+https://github.com/ManageIQ/manageiq-api-client-python.git@fd3893d51a0a25daffb9db7723dc15feb2877c42#egg=manageiq-client
+-e git+https://github.com/ManageIQ/manageiq-api-client-python.git#egg=manageiq-client
 PyYAML==3.12
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
-manageiq-client==0.3.0
+-e git+https://github.com/ManageIQ/manageiq-api-client-python.git@fd3893d51a0a25daffb9db7723dc15feb2877c42#egg=manageiq-client
 PyYAML==3.12
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==6.7
--e git+https://github.com/ManageIQ/manageiq-api-client-python.git#egg=manageiq-client
+pbr==3.1.1
+-e git+https://github.com/ManageIQ/manageiq-api-client-python.git@fd3893d51a0a25daffb9db7723dc15feb2877c42#egg=manageiq_client
 PyYAML==3.12
 requests==2.18.4


### PR DESCRIPTION
It is recommended from ManageIQ that multiple REST calls should use the token for authentication.
Authentication will always use a token, authentication will work the following way:

1. If a user supplies a token, attempt to auth w/the token and if it fails, authentication will fail
2. If the user does not supply a token, check for $HOME/.miqcli/auth file
    validate that it is good,
    if not use, passed username/password to generate a new token, and update $HOME/.miqcli/auth
    else
    auth fails
3. create $HOME/.miqcli/auth
   use username/password to generate a new token, and update $HOME/.miqcli/auth

Temporary change:
updating the git location to use github's master
I couldn't use the latest released (0.3.0), as token support was recently added.
This can be update as soon as: https://github.com/ManageIQ/manageiq-api-client-python/issues/31 is resolved, to release a new version of manageiq-api-client.

This PR closes #33 