### PR TITLE
bypass creating an api connection when the help parameter is given

### DIFF
--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -210,7 +210,9 @@ class SubCollections(click.MultiCommand):
         :param ctx: Click context.
         :type ctx: Namespace
         """
-        self.collection.connect()
+        if '--help' not in ctx.args:
+            # help does not need an api connection, it shows params and exits
+            self.collection.connect()
         super(SubCollections, self).invoke(ctx)
 
 


### PR DESCRIPTION
By default when a commands sub-command is invoked, it will create an
api connection to the MIQ endpoint. This means any parameter given when
the sub-command is invoked would attempt to connect to the endpoint. It
should not for the help parameter since its purpose is to show the
available parameters and exit. This patch resolves connecting when help
is given.

This PR fixes #37 