### PR TITLE
fix package list of importables

### DIFF
--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -21,7 +21,7 @@ import errno
 from types import FunctionType
 
 
-__all__ = ['get_class_methods']
+__all__ = ['Config', 'get_class_methods']
 
 
 class Config(dict):


### PR DESCRIPTION
This commit adds Config into the list of packages to be
importable in case the user uses the wildcard '*'

closes #47 