### PR TITLE
improve how we return information back to the user

### DIFF
--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -244,24 +244,29 @@ cli = ManageIQ(
         ),
         click.Option(
             param_decls=['--token'],
-            help='token used for authentication to the server.'
+            help='Token used for authentication to the server.'
         ),
         click.Option(
             param_decls=['--url'],
-            help='url for the ManageIQ appliance.'
+            help='URL for the ManageIQ appliance.'
         ),
         click.Option(
             param_decls=['--username'],
-            help='username used for authentication to the server.'
+            help='Username used for authentication to the server.'
         ),
         click.Option(
             param_decls=['--password'],
-            help='password used for authentication to the server.'
+            help='Password used for authentication to the server.'
         ),
         click.Option(
             param_decls=['--enable-ssl-verify/--disable-ssl-verify'],
             default=None,
-            help='enable or disable ssl verification, default is on.'
+            help='Enable or disable ssl verification, default is on.'
+        ),
+        click.Option(
+            param_decls=['--verbose'],
+            is_flag=True,
+            help='Verbose mode.'
         )
     ]
 )

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     'username': 'admin',
     'password': 'smartvm',
     'url': 'https://localhost:8443',
-    'enable_ssl_verify': False
+    'enable_ssl_verify': False,
+    'verbose': False
 }
 AUTHDIR = os.path.join(os.path.expanduser('~'), ".miqcli/auth")

--- a/miqcli/utils/log.py
+++ b/miqcli/utils/log.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import click
+
+__all__ = ['info', 'debug', 'error', 'warning']
+
+
+def __log(message, level, bold=False, fg=None):
+    """Base function to log messages using click library.
+
+    Function is private and not visible from other modules. Modules should
+    use the logging level functions to log messages.
+
+    :param message: Message content
+    :type message: str
+    :param level: Logging level
+    :type level: str
+    :param bold: Bold style text
+    :type bool: bool
+    :param fg: Text foreground color
+    :type fg: str
+    """
+    click.secho('{0}: {1}'.format(level.upper(), message), bold=bold, fg=fg)
+
+
+def info(message):
+    """Prints info level messages to the consoles standard output.
+
+    :param message: Message to print
+    :type message: str
+    """
+    __log(message, 'info')
+
+
+def debug(message):
+    """Prints debug level messages.
+
+    :param message: Message content
+    :type message: str
+    """
+    if click.get_current_context().parent.params['verbose']:
+        __log(message, 'debug')
+
+
+def error(message, abort=False, rc=1):
+    """Prints error level messages.
+
+    :param message: Message content
+    :type message: str
+    :param abort: Abort the program
+    :type abort: bool
+    :param rc: Exit code to abort with
+    :type rc: int
+    """
+    __log(message, 'error', bold=True, fg='red')
+    if abort:
+        raise SystemExit(rc)
+
+
+def warning(message):
+    """Prints warning level messages.
+
+    :param message: Message content
+    :type message: str
+    """
+    __log(message, 'warning', fg='yellow')


### PR DESCRIPTION
This commit aims to resolve how we log messages back to the user based
on a pass or fail actions. Currently we are raising exceptions which
provide the user with a stacktrace. A new module under the utils
package has been created to provide an easy way to log messages. It
provides log messages for (info, debug, error, warning, critical). The
logging is done using clicks secho function. With this module any
module within the cli can import and use these logging functions.

It also provides the ability to abort the program setting the return
code to exit with after logging a message with the following logging
levels (error, warning, critical).

A new global option has been added (--verbose). This will allow the
user to enable verbose mode. Verbose mode can be useful for displaying
log messages using debug logging level. Providing more information for
troubleshooting purposes.

Closes #44