### PR TITLE
fix logging debug messages within sub-commands

### DIFF
--- a/miqcli/utils/log.py
+++ b/miqcli/utils/log.py
@@ -52,7 +52,7 @@ def debug(message):
     :param message: Message content
     :type message: str
     """
-    if click.get_current_context().parent.params['verbose']:
+    if click.get_current_context().find_root().params['verbose']:
         __log(message, 'debug')
 
 


### PR DESCRIPTION
This commit resolves a bug found when trying to log debug level
messages within the sub-command layer of the CLI. Originally it was
getting the current context and trying to see if verbose mode was set.
It was getting the context for the sub-command and not the root context.
The root context is the one that allows you to enable verbose
mode and saves its value. Now the debug function will get the
root context and not raise a KeyError. Allowing sub-commands to log
debug messages.

Closes #51