### PR TITLE
improve the config class

### DIFF
--- a/miqcli/collections/__init__.py
+++ b/miqcli/collections/__init__.py
@@ -13,18 +13,3 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
-from miqcli.api import ClientAPI
-
-
-class Collection(ClientAPI):
-    """
-    Collection Class
-    """
-
-    def __init__(self, settings):
-        """
-        :param settings: MIQ settings
-        :type settings: dict
-        """
-        super(Collection, self).__init__(settings)

--- a/miqcli/collections/actions.py
+++ b/miqcli/collections/actions.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Actions collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/alert_definitions.py
+++ b/miqcli/collections/alert_definitions.py
@@ -14,20 +14,23 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Alert definitions collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/alerts.py
+++ b/miqcli/collections/alerts.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Alerts collections."""

--- a/miqcli/collections/arbitration_profiles.py
+++ b/miqcli/collections/arbitration_profiles.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Arbitration profiles collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/arbitration_rules.py
+++ b/miqcli/collections/arbitration_rules.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Arbitration rules collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/arbitration_settings.py
+++ b/miqcli/collections/arbitration_settings.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Arbitration settings collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/authentications.py
+++ b/miqcli/collections/authentications.py
@@ -14,20 +14,23 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Authentications collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/automate.py
+++ b/miqcli/collections/automate.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Automate collections."""

--- a/miqcli/collections/automate_domains.py
+++ b/miqcli/collections/automate_domains.py
@@ -14,16 +14,18 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Automate domains collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def refresh_from_source(self):
         """Refresh from source."""
         raise NotImplementedError

--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -14,20 +14,23 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Automation requests collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def approve(self):
         """Approve."""
         raise NotImplementedError
 
+    @client_api
     def deny(self):
         """Deny."""
         raise NotImplementedError

--- a/miqcli/collections/availability_zones.py
+++ b/miqcli/collections/availability_zones.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Availability zones collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/blueprints.py
+++ b/miqcli/collections/blueprints.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Blueprints collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def publish(self):
         """Publish."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/categories.py
+++ b/miqcli/collections/categories.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Categories collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/chargebacks.py
+++ b/miqcli/collections/chargebacks.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Chargebacks collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/cloud_networks.py
+++ b/miqcli/collections/cloud_networks.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Cloud networks collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/cloud_tenants.py
+++ b/miqcli/collections/cloud_tenants.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Cloud tenants collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/cloud_volumes.py
+++ b/miqcli/collections/cloud_volumes.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Cloud volumes collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/clusters.py
+++ b/miqcli/collections/clusters.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Clusters collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/conditions.py
+++ b/miqcli/collections/conditions.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Conditions collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/configuration_script_payloads.py
+++ b/miqcli/collections/configuration_script_payloads.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Configuration script payloads collections."""

--- a/miqcli/collections/configuration_script_sources.py
+++ b/miqcli/collections/configuration_script_sources.py
@@ -14,20 +14,23 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Configuration script sources collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/container_deployments.py
+++ b/miqcli/collections/container_deployments.py
@@ -14,16 +14,18 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Container deployments collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError

--- a/miqcli/collections/currencies.py
+++ b/miqcli/collections/currencies.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Currencies collections."""

--- a/miqcli/collections/data_stores.py
+++ b/miqcli/collections/data_stores.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Data stores collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/events.py
+++ b/miqcli/collections/events.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Events collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/features.py
+++ b/miqcli/collections/features.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Features collections."""

--- a/miqcli/collections/flavors.py
+++ b/miqcli/collections/flavors.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Flavors collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/groups.py
+++ b/miqcli/collections/groups.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Groups collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/hosts.py
+++ b/miqcli/collections/hosts.py
@@ -14,16 +14,18 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Hosts collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError

--- a/miqcli/collections/instances.py
+++ b/miqcli/collections/instances.py
@@ -14,44 +14,53 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Instances collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def terminate(self):
         """Terminate."""
         raise NotImplementedError
 
+    @client_api
     def stop(self):
         """Stop."""
         raise NotImplementedError
 
+    @client_api
     def start(self):
         """Start."""
         raise NotImplementedError
 
+    @client_api
     def pause(self):
         """Pause."""
         raise NotImplementedError
 
+    @client_api
     def suspend(self):
         """Suspend."""
         raise NotImplementedError
 
+    @client_api
     def shelve(self):
         """Shelve."""
         raise NotImplementedError
 
+    @client_api
     def reboot_guest(self):
         """Reboot guest."""
         raise NotImplementedError
 
+    @client_api
     def reset(self):
         """Reset."""
         raise NotImplementedError

--- a/miqcli/collections/load_balancers.py
+++ b/miqcli/collections/load_balancers.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Load balancers collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/measures.py
+++ b/miqcli/collections/measures.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Measures collections."""

--- a/miqcli/collections/notifications.py
+++ b/miqcli/collections/notifications.py
@@ -14,16 +14,18 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Notifications collections."""
 
+    @client_api
     def mark_as_seen(self):
         """Mark as seen."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/orchestration_templates.py
+++ b/miqcli/collections/orchestration_templates.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Orchestration templates collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def copy(self):
         """Copy."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/pictures.py
+++ b/miqcli/collections/pictures.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Pictures collections."""
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError

--- a/miqcli/collections/policies.py
+++ b/miqcli/collections/policies.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Policies collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/policy_actions.py
+++ b/miqcli/collections/policy_actions.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Policy actions collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/policy_profiles.py
+++ b/miqcli/collections/policy_profiles.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Policy profiles collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/providers.py
+++ b/miqcli/collections/providers.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Providers collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def refresh(self):
         """Refresh."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/provision_dialogs.py
+++ b/miqcli/collections/provision_dialogs.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Provision dialogs collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/provision_requests.py
+++ b/miqcli/collections/provision_requests.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Provision requests collections."""
 
+    @client_api
     def approve(self):
         """Approve."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def deny(self):
         """Deny."""
         raise NotImplementedError
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/rates.py
+++ b/miqcli/collections/rates.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Rates collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/regions.py
+++ b/miqcli/collections/regions.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Regions collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/reports.py
+++ b/miqcli/collections/reports.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Reports collections."""
 
+    @client_api
     def imports(self):
         """Import."""
         # NOTE: real action name is import but import is python built-in..

--- a/miqcli/collections/request_tasks.py
+++ b/miqcli/collections/request_tasks.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Request tasks collections."""

--- a/miqcli/collections/requests.py
+++ b/miqcli/collections/requests.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Requests collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def approve(self):
         """Approve."""
         raise NotImplementedError
 
+    @client_api
     def deny(self):
         """Deny."""
         raise NotImplementedError

--- a/miqcli/collections/resource_pools.py
+++ b/miqcli/collections/resource_pools.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Resource pools collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/results.py
+++ b/miqcli/collections/results.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Results collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/roles.py
+++ b/miqcli/collections/roles.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Roles collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def add(self):
         """Add."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/security_groups.py
+++ b/miqcli/collections/security_groups.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Security groups collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/servers.py
+++ b/miqcli/collections/servers.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Servers collections."""

--- a/miqcli/collections/service_catalogs.py
+++ b/miqcli/collections/service_catalogs.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Service catalogs collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def add(self):
         """Add."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/service_orders.py
+++ b/miqcli/collections/service_orders.py
@@ -14,28 +14,33 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Service orders collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError
 
+    @client_api
     def copy(self):
         """Copy."""
         raise NotImplementedError

--- a/miqcli/collections/service_requests.py
+++ b/miqcli/collections/service_requests.py
@@ -14,36 +14,43 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Service requests collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def approve(self):
         """Approve."""
         raise NotImplementedError
 
+    @client_api
     def deny(self):
         """Deny."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError
 
+    @client_api
     def add_approver(self):
         """Add approver."""
         raise NotImplementedError
 
+    @client_api
     def remove_approver(self):
         """Remove approver."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError

--- a/miqcli/collections/service_templates.py
+++ b/miqcli/collections/service_templates.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Service templates collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/services.py
+++ b/miqcli/collections/services.py
@@ -14,64 +14,78 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Services collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def retire(self):
         """Retire."""
         raise NotImplementedError
 
+    @client_api
     def set_ownership(self):
         """Set ownership."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError
 
+    @client_api
     def start(self):
         """Start."""
         raise NotImplementedError
 
+    @client_api
     def stop(self):
         """Stop."""
         raise NotImplementedError
 
+    @client_api
     def suspend(self):
         """Suspend."""
         raise NotImplementedError
 
+    @client_api
     def assign_tags(self):
         """Assign tags."""
         raise NotImplementedError
 
+    @client_api
     def unassign_tags(self):
         """Unassign tags."""
         raise NotImplementedError
 
+    @client_api
     def add_resource(self):
         """Add resource."""
         raise NotImplementedError
 
+    @client_api
     def remote_all_resources(self):
         """Remove all resources."""
         raise NotImplementedError
 
+    @client_api
     def remove_resource(self):
         """Remove resource."""
         raise NotImplementedError

--- a/miqcli/collections/settings.py
+++ b/miqcli/collections/settings.py
@@ -14,8 +14,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
 
-
-class Collections(Collection):
+class Collections(object):
     """Settings collections."""

--- a/miqcli/collections/tags.py
+++ b/miqcli/collections/tags.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Tags collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/tasks.py
+++ b/miqcli/collections/tasks.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Tasks collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/templates.py
+++ b/miqcli/collections/templates.py
@@ -14,20 +14,23 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Templates collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def set_ownership(self):
         """Set ownership."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/tenants.py
+++ b/miqcli/collections/tenants.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Tenants collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/users.py
+++ b/miqcli/collections/users.py
@@ -14,24 +14,28 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Users collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def create(self):
         """Create."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError

--- a/miqcli/collections/virtual_templates.py
+++ b/miqcli/collections/virtual_templates.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Virtual templates collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/collections/vms.py
+++ b/miqcli/collections/vms.py
@@ -14,96 +14,118 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Virtual machines collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError
 
+    @client_api
     def edit(self):
         """Edit."""
         raise NotImplementedError
 
+    @client_api
     def add_lifecycle_event(self):
         """Add lifecycle event."""
         raise NotImplementedError
 
+    @client_api
     def add_event(self):
         """Add event."""
         raise NotImplementedError
 
+    @client_api
     def refresh(self):
         """Refresh."""
         raise NotImplementedError
 
+    @client_api
     def shutdown_guest(self):
         """Shutdown guest."""
         raise NotImplementedError
 
+    @client_api
     def reboot_guest(self):
         """Reboot guest."""
         raise NotImplementedError
 
+    @client_api
     def start(self):
         """Start."""
         raise NotImplementedError
 
+    @client_api
     def stop(self):
         """Stop."""
         raise NotImplementedError
 
+    @client_api
     def suspend(self):
         """Suspend."""
         raise NotImplementedError
 
+    @client_api
     def shelve(self):
         """Shelve."""
         raise NotImplementedError
 
+    @client_api
     def shelve_offload(self):
         """Shelve offload."""
         raise NotImplementedError
 
+    @client_api
     def pause(self):
         """Pause."""
         raise NotImplementedError
 
+    @client_api
     def request_console(self):
         """Request console."""
         raise NotImplementedError
 
+    @client_api
     def reset(self):
         """Reset."""
         raise NotImplementedError
 
+    @client_api
     def retire(self):
         """Retire."""
         raise NotImplementedError
 
+    @client_api
     def set_owner(self):
         """Set owner."""
         raise NotImplementedError
 
+    @client_api
     def set_ownership(self):
         """Set ownership."""
         raise NotImplementedError
 
+    @client_api
     def scan(self):
         """Scan."""
         raise NotImplementedError
 
+    @client_api
     def delete(self):
         """Delete."""
         raise NotImplementedError
 
+    @client_api
     def assign_tags(self):
         """Assign tags."""
         raise NotImplementedError
 
+    @client_api
     def unassign_tags(self):
         """Unassign tags."""
         raise NotImplementedError

--- a/miqcli/collections/zones.py
+++ b/miqcli/collections/zones.py
@@ -14,12 +14,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from miqcli.collections import Collection
+from miqcli.decorators import client_api
 
 
-class Collections(Collection):
+class Collections(object):
     """Zones collections."""
 
+    @client_api
     def query(self):
         """Query."""
         raise NotImplementedError

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -16,14 +16,17 @@
 
 import os
 
+import click
+
 VERSION = '0.0.0'
 PACKAGE = 'miqcli'
 PYPI = 'https://pypi.python.org/pypi'
 PROJECT_ROOT = os.path.dirname(__file__)
 COLLECTIONS_ROOT = os.path.join(PROJECT_ROOT, 'collections')
 COLLECTIONS_PACKAGE = PACKAGE + '.' + 'collections'
-MIQCLI_CFG_FILE_LOC = '/etc/miqcli'
-MIQCLI_CFG_NAME = 'miqcli'
+CFG_DIR = '/etc/miqcli'
+CFG_NAME = 'miqcli'
+CFG_FILE_EXT = ['.yml', '.yaml']
 DEFAULT_CONFIG = {
     'username': 'admin',
     'password': 'smartvm',
@@ -32,3 +35,37 @@ DEFAULT_CONFIG = {
     'verbose': False
 }
 AUTHDIR = os.path.join(os.path.expanduser('~'), ".miqcli/auth")
+
+GLOBAL_PARAMS = [
+    click.Option(
+        param_decls=['--version'],
+        is_flag=True,
+        help='Show version and exit.'
+    ),
+    click.Option(
+        param_decls=['--token'],
+        help='Token used for authentication to the server.'
+    ),
+    click.Option(
+        param_decls=['--url'],
+        help='URL for the ManageIQ appliance.'
+    ),
+    click.Option(
+        param_decls=['--username'],
+        help='Username used for authentication to the server.'
+    ),
+    click.Option(
+        param_decls=['--password'],
+        help='Password used for authentication to the server.'
+    ),
+    click.Option(
+        param_decls=['--enable-ssl-verify/--disable-ssl-verify'],
+        default=None,
+        help='Enable or disable ssl verification, default is on.'
+    ),
+    click.Option(
+        param_decls=['--verbose'],
+        is_flag=True,
+        help='Verbose mode.'
+    )
+]

--- a/miqcli/decorators.py
+++ b/miqcli/decorators.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Decorator module contains decorators used throughout the cli modules."""
+
+from functools import wraps
+
+from miqcli.utils import get_client_api_pointer
+
+
+def client_api(method):
+    """Client API decorator.
+
+    :param method: Collection method
+    :type method: object
+    :return: The wrapper function
+    """
+    @wraps(method)
+    def func(*args, **kwargs):
+        """Invoke the given collection method.
+
+        Before calling the method, it will set a new collection attribute.
+        This attribute is the manageiq client api pointer. This attribute
+        will be used to perform requests using the client api library to
+        the server. This removes the need for the class to get the object
+        from the click context and then use it.
+
+        :param args: Arguments
+        :type args: tuple
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+        :return: The invoked collection method
+        """
+        setattr(args[0], 'api', get_client_api_pointer())
+        return method(*args, **kwargs)
+    return func


### PR DESCRIPTION
This commit improves the logging messages with the config class when
an error may occur. The previous design silenced every message so the
user would never know exactly why their config may not be loaded
properly. This is now handled by the verbose option the cli has. It
provides the ability to give more information back to the user if
enabled.

In order for this to work, I needed to move loading config settings
right before we invoke the command. Why? We do not have the verbose
setting until we invoke the command. Previously we loaded the config
settings right before the cli began and at that point we would never
have the value the user gives for verbose option.

With the change for moving where we load the config, it required a
change to how each collection class has access to the client api
pointer. Previously each collection class would inherit the ClientAPI
to have access to it. This was fine because we had all the config
settings at that time. Click needs the collection class object in order
to build the cli. With the config settings loaded before the command
is invoked, the client api pointer previously created would be invalid.
With the new design, right before invoking the command, we create a
client api pointer with the final config settings loaded, create the
connection to the server and save the pointer within click context.
Each collection class method has a decorator which provides the class
with the client api pointer. Providing the same ability the previous
design did when inheriting the ClientAPI class.

Closes #55 and resolves #50