### PR TITLE
add abort logging function

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -26,6 +26,8 @@ from requests.exceptions import ConnectionError
 from miqcli.constants import AUTHDIR, DEFAULT_CONFIG
 from miqcli.utils import log
 
+__all__ = ['ClientAPI']
+
 
 class ClientAPI(object):
     """ManageIQ API client class.
@@ -51,7 +53,7 @@ class ClientAPI(object):
             os.makedirs(os.path.dirname(AUTHDIR))
         except OSError as e:
             if e.errno != errno.EEXIST:
-                log.error('Error creating user miqcli folder', abort=True)
+                log.abort('Error creating user miqcli folder.')
 
         # url details
         self._url = settings.get('url', DEFAULT_CONFIG['url'])
@@ -124,8 +126,7 @@ class ClientAPI(object):
         else:
             # check if given token is valid
             if not self._valid_token(token):
-                log.error('Given token {0} is not valid.'.format(token),
-                          abort=True)
+                log.abort('Given token {0} is not valid.'.format(token))
 
         # always save the token in the auth file
         self._set_auth_file(token)
@@ -141,7 +142,7 @@ class ClientAPI(object):
             with open(AUTHDIR, "w") as fp:
                 fp.write(token)
         except OSError as e:
-            log.error('Error setting token file. %s' % e, abort=True)
+            log.abort('Error setting token file. %s' % e)
 
     @staticmethod
     def _get_from_auth_file():
@@ -153,7 +154,7 @@ class ClientAPI(object):
                 token = fp.read().strip()
         except IOError as e:
             if e.errno != errno.ENOENT:
-                log.error('Error reading local auth file.', abort=True)
+                log.abort('Error reading local auth file.')
             return None
         return token
 
@@ -190,7 +191,7 @@ class ClientAPI(object):
         the client will exit with -1.
         """
         if self._username is None or self._password is None:
-            log.error('You need to set username and password.', abort=True)
+            log.abort('You need to set username and password.')
         auth_endpoint = self._url + "/auth"
         try:
             output = requests.get(auth_endpoint,
@@ -201,11 +202,11 @@ class ClientAPI(object):
             if output.status_code == 200:
                 return output.json()["auth_token"]
             else:
-                log.error('Unsuccessful attempt to authenticate: '
-                          '{0}'.format(output.status_code), abort=True)
+                log.abort('Unsuccessful attempt to authenticate: '
+                          '{0}'.format(output.status_code))
         except ConnectionError:
-            log.error('Error connecting to service. Check your connection '
-                      'settings.', abort=True)
+            log.abort('Error connecting to service. Check your connection '
+                      'settings.')
 
     def _connect(self):
         """
@@ -216,7 +217,6 @@ class ClientAPI(object):
                                           dict(token=self._token),
                                           verify_ssl=self._verify_ssl)
         except APIException as e:
-            log.error('Error creating library pointer - '
-                      '{0}'.format(e.message), abort=True)
+            log.abort('Error creating library pointer - {0}'.format(e.message))
         except Exception as e:
-            log.error('{0}'.format(e.message), abort=True)
+            log.abort('{0}'.format(e.message))

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -76,7 +76,7 @@ class Config(dict):
         except yaml.YAMLError as e:
             if self._verbose:
                 log.debug('Standard error: {0}'.format(e.sterror))
-                log.error('Error in config {0}'.format(_cfg_file), abort=True)
+                log.abort('Error in config {0}.'.format(_cfg_file))
 
     def from_env(self, var):
         """Load configuration settings from environment variable.
@@ -123,4 +123,4 @@ def get_client_api_pointer():
     try:
         return click.get_current_context().find_root().client_api
     except AttributeError:
-        log.error('Unable to get client_api pointer.', abort=True)
+        log.error('Unable to get client api pointer.')

--- a/miqcli/utils/log.py
+++ b/miqcli/utils/log.py
@@ -16,7 +16,7 @@
 
 import click
 
-__all__ = ['info', 'debug', 'error', 'warning']
+__all__ = ['info', 'debug', 'error', 'warning', 'abort']
 
 
 def __log(message, level, bold=False, fg=None):
@@ -30,7 +30,7 @@ def __log(message, level, bold=False, fg=None):
     :param level: Logging level
     :type level: str
     :param bold: Bold style text
-    :type bool: bool
+    :type bold: bool
     :param fg: Text foreground color
     :type fg: str
     """
@@ -38,7 +38,11 @@ def __log(message, level, bold=False, fg=None):
 
 
 def info(message):
-    """Prints info level messages to the consoles standard output.
+    """Info level messages.
+
+    Info messages should be used when the program needs to provide the user
+    with information at runtime. I.e. providing the user with a message
+    stating which action is being processed, etc..
 
     :param message: Message to print
     :type message: str
@@ -47,7 +51,13 @@ def info(message):
 
 
 def debug(message):
-    """Prints debug level messages.
+    """Debug level messages.
+
+    Debug messages should be used when the program wants to provide the
+    user with more information at runtime. These can be good for explaining
+    step by step a request being processed (if the user wishes to see the
+    process). These messages by default will not be logged and only will be
+    logged when --verbose option is enabled.
 
     :param message: Message content
     :type message: str
@@ -56,25 +66,42 @@ def debug(message):
         __log(message, 'debug')
 
 
-def error(message, abort=False, rc=1):
-    """Prints error level messages.
+def error(message):
+    """Error level messages.
+
+    Error messages should be used when the program needs to alert the user
+    when something went wrong. I.e. a request was unable to be processed,
+    connection failed, etc..
 
     :param message: Message content
     :type message: str
-    :param abort: Abort the program
-    :type abort: bool
-    :param rc: Exit code to abort with
-    :type rc: int
     """
     __log(message, 'error', bold=True, fg='red')
-    if abort:
-        raise SystemExit(rc)
 
 
 def warning(message):
-    """Prints warning level messages.
+    """Logs warning level messages.
+
+    Warning messages should be used when the program needs to alert the user
+    that it may not function as designed. I.e. user did not supply the
+    correct values, etc..
 
     :param message: Message content
     :type message: str
     """
     __log(message, 'warning', fg='yellow')
+
+
+def abort(message, rc=1):
+    """Logs error level message and aborts the program.
+
+    Abort should be self explanatory. It will abort the program when it is
+    unable to proceed processing the request given.
+
+    :param message: Message content
+    :type message: str
+    :param rc: Exit code to abort with
+    :type rc: int
+    """
+    error(message)
+    raise SystemExit(rc)


### PR DESCRIPTION
This commit adds a new logging function (log.abort()) to the CLI. It
should be used when you want to log and exit the CLI. The abort function
accepts a message which will then log it as an error message and exit
with a return code of non zero. Previously the log.error() would allow
you to exit the CLI but it will now just log the messages.

Also includes updated doc strings for each logging function. They
explain when it is best to use each one.

Closes #64