### PR TITLE
log warning message when default configuration is used

### DIFF
--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -27,7 +27,8 @@ from miqcli.api import ClientAPI
 from miqcli._compat import ServerProxy
 from miqcli.constants import CFG_DIR, CFG_NAME, COLLECTIONS_PACKAGE, \
     COLLECTIONS_ROOT, DEFAULT_CONFIG, GLOBAL_PARAMS, PACKAGE, PYPI, VERSION
-from miqcli.utils import Config, get_class_methods
+from miqcli.utils import Config, get_class_methods, log, \
+    is_default_config_used
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -251,6 +252,10 @@ class SubCollections(click.MultiCommand):
             click.get_current_context().find_root().params.update(
                 dict(config)
             )
+
+            # notify user if default config is used
+            if is_default_config_used():
+                log.warning('Default configuration is used.')
 
             # create the client api object
             client = ClientAPI(click.get_current_context().find_root().params)

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -60,8 +60,7 @@ DEFAULT_CONFIG = {
     'username': 'admin',
     'password': 'smartvm',
     'url': 'https://localhost:8443',
-    'enable_ssl_verify': False,
-    'verbose': False
+    'enable_ssl_verify': False
 }
 
 #: filesystem root for miqcli authentication store

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -24,7 +24,8 @@ import click
 from miqcli.constants import CFG_FILE_EXT
 from miqcli.utils import log
 
-__all__ = ['Config', 'get_class_methods', 'get_client_api_pointer']
+__all__ = ['Config', 'get_class_methods', 'get_client_api_pointer',
+           'is_default_config_used']
 
 
 class Config(dict):
@@ -124,3 +125,26 @@ def get_client_api_pointer():
         return click.get_current_context().find_root().client_api
     except AttributeError:
         log.error('Unable to get client api pointer.')
+
+
+def is_default_config_used():
+    """Is the default configuration used?
+
+    :return: True - defaults used, False - defaults not used
+    :rtype: bool
+    """
+    status = True
+
+    # get parent context
+    ctx = click.get_current_context().find_root()
+
+    # compare default config settings with final parameters
+    for key, value in ctx.default_map.items():
+        if value == ctx.params[key]:
+            # option values match
+            continue
+        else:
+            # option values differ
+            status = False
+            break
+    return status


### PR DESCRIPTION
This commit provides the user with a helpful message when the cli is
using the default configuration. A comparison is performed between the
default settings and the final cli parameters to determine if the
message is logged.

Removes verbose from DEFAULT_CONFIG constant. Those settings should be
strictly for the client api.

Closes #66