### PR TITLE
handle exception raised when command/sub-command is invalid

### DIFF
--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -28,7 +28,7 @@ from miqcli._compat import ServerProxy
 from miqcli.constants import CFG_DIR, CFG_NAME, COLLECTIONS_PACKAGE, \
     COLLECTIONS_ROOT, DEFAULT_CONFIG, GLOBAL_PARAMS, PACKAGE, PYPI, VERSION
 from miqcli.utils import Config, get_class_methods, log, \
-    is_default_config_used, display_commands
+    is_default_config_used, _abort_invalid_commands
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -86,10 +86,7 @@ class ManageIQ(click.MultiCommand):
         try:
             miq_module = import_module(COLLECTIONS_PACKAGE + '.' + name)
         except ImportError:
-            # invalid command, display list of available commands/exit
-            display_commands(ctx)
-            log.abort('Command "{0}" is invalid. Please choose a valid command'
-                      ' from the list above.'.format((name)))
+            _abort_invalid_commands(ctx, name)
         collection_cls = getattr(miq_module, 'Collections')
         return SubCollections(collection_cls)
 
@@ -236,10 +233,7 @@ class SubCollections(click.MultiCommand):
         """
         # first lets make sure the sub-command given is valid
         if ctx.protected_args[0] not in self.list_commands(ctx):
-            # invalid command, display list of available commands/exit
-            display_commands(ctx)
-            log.abort('Command "{0}" is invalid. Please choose a valid command'
-                      ' from the list above.'.format((ctx.protected_args[0])))
+            _abort_invalid_commands(ctx, ctx.protected_args[0])
 
         if '--help' not in ctx.args:
             # get parent context

--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -89,7 +89,7 @@ class ManageIQ(click.MultiCommand):
             # invalid command, display list of available commands/exit
             display_commands(ctx)
             log.abort('Command "{0}" is invalid. Please choose a valid command'
-                      'from the list above.'.format((name)))
+                      ' from the list above.'.format((name)))
         collection_cls = getattr(miq_module, 'Collections')
         return SubCollections(collection_cls)
 

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -25,7 +25,8 @@ from miqcli.constants import CFG_FILE_EXT
 from miqcli.utils import log
 
 __all__ = ['Config', 'get_class_methods', 'get_client_api_pointer',
-           'is_default_config_used']
+           'is_default_config_used', 'display_commands',
+           '_abort_invalid_commands']
 
 
 class Config(dict):
@@ -166,3 +167,16 @@ def display_commands(ctx):
     commands = formatter.getvalue().rstrip('\n').split('Commands:')[1]
 
     print('Commands:\n {0}'.format(commands))
+
+
+def _abort_invalid_commands(ctx, name):
+    """Abort the CLI when an invalid command is supplied.
+
+    :param ctx: Click context
+    :type ctx: Namespace
+    :param name: Command name
+    :type name: str
+    """
+    display_commands(ctx)
+    log.abort('Command "{0}" is invalid. Please choose a valid command '
+              'from the list above.'.format(name))

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -148,3 +148,21 @@ def is_default_config_used():
             status = False
             break
     return status
+
+
+def display_commands(ctx):
+    """Displays the available cli commands.
+
+    :param ctx: Click context
+    :type ctx: Namespace
+    """
+    # create clicks formatter object
+    formatter = ctx.make_formatter()
+
+    # call clicks method to get and format all available commands
+    ctx.command.format_options(ctx, formatter)
+
+    # discard options only leaving commands
+    commands = formatter.getvalue().rstrip('\n').split('Commands:')[1]
+
+    print('Commands:\n {0}'.format(commands))


### PR DESCRIPTION
Previously if you gave an invalid command, the cli would fail by
raising an exception. This commit updates the main cli class to
handle the exception and provide the user with a message/list of
available valid commands/exits.

Closes #69 

i.e.
```bash
(miq-py36) [rywillia@laptop ~]$ miqcli xyz
Commands:
 
  actions                        Actions collections.
  alert_definitions              Alert definitions collections.
  alerts                         Alerts collections.
  arbitration_profiles           Arbitration profiles collections.
  arbitration_rules              Arbitration rules collections.
  arbitration_settings           Arbitration settings collections.
  authentications                Authentications collections.
  automate                       Automate collections.
  automate_domains               Automate domains collections.
  automation_requests            Automation requests collections.
  availability_zones             Availability zones collections.
  blueprints                     Blueprints collections.
  categories                     Categories collections.
  chargebacks                    Chargebacks collections.
  cloud_networks                 Cloud networks collections.
  cloud_tenants                  Cloud tenants collections.
  cloud_volumes                  Cloud volumes collections.
  clusters                       Clusters collections.
  conditions                     Conditions collections.
  configuration_script_payloads  Configuration script payloads collections.
  configuration_script_sources   Configuration script sources collections.
  container_deployments          Container deployments collections.
  currencies                     Currencies collections.
  data_stores                    Data stores collections.
  events                         Events collections.
  features                       Features collections.
  flavors                        Flavors collections.
  groups                         Groups collections.
  hosts                          Hosts collections.
  instances                      Instances collections.
  load_balancers                 Load balancers collections.
  measures                       Measures collections.
  notifications                  Notifications collections.
  orchestration_templates        Orchestration templates collections.
  pictures                       Pictures collections.
  policies                       Policies collections.
  policy_actions                 Policy actions collections.
  policy_profiles                Policy profiles collections.
  providers                      Providers collections.
  provision_dialogs              Provision dialogs collections.
  provision_requests             Provision requests collections.
  rates                          Rates collections.
  regions                        Regions collections.
  reports                        Reports collections.
  request_tasks                  Request tasks collections.
  requests                       Requests collections.
  resource_pools                 Resource pools collections.
  results                        Results collections.
  roles                          Roles collections.
  security_groups                Security groups collections.
  servers                        Servers collections.
  service_catalogs               Service catalogs collections.
  service_orders                 Service orders collections.
  service_requests               Service requests collections.
  service_templates              Service templates collections.
  services                       Services collections.
  settings                       Settings collections.
  tags                           Tags collections.
  tasks                          Tasks collections.
  templates                      Templates collections.
  tenants                        Tenants collections.
  users                          Users collections.
  virtual_templates              Virtual templates collections.
  vms                            Virtual machines collections.
  zones                          Zones collections.
ERROR: Command "xyz" is invalid. Please choose a valid command from the list above.
(miq-py36) [rywillia@laptop ~]$ miqcli providers c
Commands:
 
  create   Create.
  delete   Delete.
  edit     Edit.
  query    Query.
  refresh  Refresh.
ERROR: Command "c" is invalid. Please choose a valid command from the list above.
```