### PR TITLE
adds a class for easy use of the client in python modules

### DIFF
--- a/miqcli/__init__.py
+++ b/miqcli/__init__.py
@@ -13,3 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+from miqcli.api import Client
+
+__all__ = ['Client']

--- a/miqcli/cli/main.py
+++ b/miqcli/cli/main.py
@@ -15,22 +15,18 @@
 #
 
 import os
-import urllib3
 from copy import copy
 from functools import wraps
-from importlib import import_module
 
 import click
 from os import listdir
 
 from miqcli.api import ClientAPI
 from miqcli._compat import ServerProxy
-from miqcli.constants import CFG_DIR, CFG_NAME, COLLECTIONS_PACKAGE, \
-    COLLECTIONS_ROOT, DEFAULT_CONFIG, GLOBAL_PARAMS, PACKAGE, PYPI, VERSION
+from miqcli.constants import CFG_DIR, CFG_NAME, COLLECTIONS_ROOT, \
+    DEFAULT_CONFIG, GLOBAL_PARAMS, PACKAGE, PYPI, VERSION
 from miqcli.utils import Config, get_class_methods, log, \
-    is_default_config_used, _abort_invalid_commands
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    is_default_config_used, _abort_invalid_commands, get_collection_class
 
 
 class ManageIQ(click.MultiCommand):
@@ -83,12 +79,7 @@ class ManageIQ(click.MultiCommand):
         :return: Click command object.
         :rtype: object
         """
-        try:
-            miq_module = import_module(COLLECTIONS_PACKAGE + '.' + name)
-        except ImportError:
-            _abort_invalid_commands(ctx, name)
-        collection_cls = getattr(miq_module, 'Collections')
-        return SubCollections(collection_cls)
+        return SubCollections(get_collection_class(ctx, name))
 
     def invoke(self, ctx):
         """Invoke the command selected.

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -14,19 +14,20 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
-import yaml
 import ast
-from types import FunctionType
+from importlib import import_module
 
 import click
+import os
+import yaml
+from types import FunctionType
 
-from miqcli.constants import CFG_FILE_EXT
+from miqcli.constants import CFG_FILE_EXT, COLLECTIONS_PACKAGE
 from miqcli.utils import log
 
 __all__ = ['Config', 'get_class_methods', 'get_client_api_pointer',
            'is_default_config_used', 'display_commands',
-           '_abort_invalid_commands']
+           '_abort_invalid_commands', 'get_collection_class']
 
 
 class Config(dict):
@@ -149,6 +150,23 @@ def is_default_config_used():
             status = False
             break
     return status
+
+
+def get_collection_class(ctx, name):
+    """Return the collection's class from a module lookup.
+
+    :param ctx: Click context
+    :type ctx: Namespace
+    :param name: Collection name
+    :type name: str
+    :return: Collection class reference
+    :rtype: class
+    """
+    try:
+        return getattr(import_module(COLLECTIONS_PACKAGE + '.' + name),
+                       'Collections')
+    except ImportError:
+        _abort_invalid_commands(ctx, name)
 
 
 def display_commands(ctx):


### PR DESCRIPTION
With the addition of a unified client class. Users will be able to use
the MIQ cli directly within python modules. This class eliminates
multiple steps the user would have had to perform. Please reference the
class doc string for more details on how to use.

It also relocates disabling the urllib3 warning message. Previously
this was done in the cli package but now is moved to the api module. It
is needed when using the client via command line or as a library import.

Closes #74 

i.e.
```python
import subprocess

from miqcli import Client

conf = dict(
    url='https://127.0.0.1:8443',
    username='admin',
    password='smartvm',
    enable_ssl_verify=False
)

client = Client(conf, verbose=True)
client.collection = 'providers'
client.collection.create('params')

# the above lines of code does the same action as the one below
subprocess.Popen('miqcli --verbose providers create params')
```