### PR TITLE
create test environment scripts to support test and CI

### DIFF
--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -1,4 +1,4 @@
-Prepare Test Environment
+Test Environment Scripts
 ========================
 
 These scripts prepare the test environment.

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -1,0 +1,43 @@
+Prepare Test Environment
+========================
+
+These scripts prepare the test environment.
+
+Requirements
+------------
+
+Prior to run these scripts, you must have:
+
+* docker
+* python docker library
+* phantomjs, set in your PATH
+* internet access because the datastore will be installed from the project's github repository.
+
+Scripts
+-------
+
+* testinstance - start/stop a ManageIQ container
+* change_configuration.js - configure the local ManageIQ instance
+* install_datastore.js - install the datastore from the manageiq-cli project
+
+
+How to execute
+--------------
+
+.. code-block:: bash
+
+    $ ./testinstance -c start
+    $ phantomjs --config phantomjs-config.json change_configuration.js
+    $ phantomjs --config phantomjs-config.json install_datastore.js
+
+
+How to stop
+-----------
+
+.. code-block:: bash
+
+    $ ./testinstance -c stop
+
+You could have given another name for the docker container. If that is what you've done, then you
+have to give the container name when calling stop otherwise it will try to delete a container named
+'miqcli_test'.

--- a/scripts/change_configuration.js
+++ b/scripts/change_configuration.js
@@ -1,0 +1,83 @@
+"use strict";
+var sys = require("system"),
+    page = require("webpage").create(),
+    MIQ_URL = "https://localhost:8443/";
+
+// page settings
+page.viewportSize = { width: 1920, height: 1080 };
+page.settings.userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.119 Safari/537.36';
+page.settings.javascriptEnabled = true;
+
+// phantomjs settings
+phantom.cookiesEnabled = true;
+phantom.javascriptEnabled = true;
+
+page.onConsoleMessage = function(msg) {
+  system.stderr.writeLine('console: ' + msg);
+};
+
+// load login page
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 1: Load '" + MIQ_URL + "'");
+  page.open(MIQ_URL);
+}, 5000);
+
+// input credentials
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 2: Login into the ManageIQ instance");
+  page.evaluate(function() {
+    document.querySelector("input[name='user_name']").value = "admin";
+    document.querySelector("input[name='user_password']").value = "smartvm";
+    $("#login").click();
+  });
+}, 10000);
+
+// go to the configuration page
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 3: Load 'https://localhost:8443/ops/explorer'");
+  page.open("https://localhost:8443/ops/explorer");
+}, 15000);
+
+// change settings
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 4: Click server_role_git_owner switch");
+  
+  // We want server roles git owner to be swtiched on.
+  var switch_value = page.evaluate(function() {
+    return $("input[name='server_roles_git_owner']").bootstrapSwitch('state');
+  });
+  if (switch_value == false) {
+    console.log("    Git owner switch is OFF. Setting to ON.")
+    page.evaluate(function() {
+      $("input[name='server_roles_git_owner']").bootstrapSwitch('toggleState');
+    });
+  } else {
+    console.log("    Git owner switch is ON. Nothing to do.")
+  }
+
+  // we can set more stuff here later...
+
+}, 20000);
+
+// save the changes. If nothing changes, it won't hurt clicking on save anyway
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 5: Save configuration changes");
+  page.evaluate(function() {
+    $('button[alt="Save Changes"]').click();
+  });
+}, 20000);
+
+// done
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 6: Close page and shutdown");
+  page.close();
+  setTimeout(function(){
+      phantom.exit();
+  }, 100);
+}, 28000);

--- a/scripts/init_testenv
+++ b/scripts/init_testenv
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+
+#
+# This script was built specifically to run integration tests
+# for this project. It starts a container instance in Docker
+# running ManageIQ, a port redirect at 8443. The default username
+# for the oficial image is 'admin' and the password is 'smartvm'
+#
+# To start a container:
+# $ scripts/init_testenv -c start [-n <container_name>]
+#
+# To stop and remove the container:
+# $ scripts/init_testenv -c stop [-n <container_name>]
+#
+# WARNING: this script can delete a running container in your
+# system if you specify the name of this container with the
+# 'stop' command.
+#
+
+
+import sys
+import getopt
+import argparse
+import time
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+import requests
+
+# Constants
+MANAGEIQ_IMAGE_NAME = u'docker.io/manageiq/manageiq'
+MANAGEIQ_IMAGE_TAG = u'fine-4'
+MANAGEIQ_IMAGE_SHA256 = u'sha256:cb94310bdfc63fbbf98741772334fc197d0ce2a932e0a3cd0764156c70d20462'
+
+# Globals
+client = None
+container = None
+
+# check if docker lib is installed
+try:
+    import docker
+except:
+    print('Docker python lib not found.')
+    exit(1)
+
+
+def build_docker_image_id(name, tag=None, digest=None):
+    """
+    Build an image ID to pull from docker. Digest has preference.
+    The format is accordingly with the format at Docker's documentation:
+
+    NAME[:TAG|@DIGEST]
+
+    """
+    if digest:
+        return '{0}{1}'.format(name, '@%s' % digest).strip()
+    else:
+        return '{0}{1}'.format(
+            name, ':%s' % tag if tag is not None else '').strip()
+
+
+def pull_docker_image(name, tag=None, stream=False,
+                      insecure_registry=False, auth_config=None,
+                      decode=False):
+    """Pull docker image"""
+    global client
+    print("Downloading image...")
+    return client.images.pull(name=name, tag=tag, stream=stream,
+                              insecure_registry=insecure_registry,
+                              auth_config=auth_config, decode=decode)
+
+
+def check_docker_image_exist(name, tag=None):
+    global client
+    repotag = build_docker_image_id(name, tag=tag)
+    for img in client.images.list():
+        if img.attrs.has_key('RepoTags') and repotag \
+                in img.attrs['RepoTags']:
+            print("Image '%s' found." % repotag)
+            return True
+    return False
+
+
+def connect():
+    """Create a client connection with local docker"""
+    global client
+    # check if docker exist and is running
+    client = docker.from_env()
+    if not client.ping():
+        print('Docker is not running or not installed.')
+        exit(1)
+
+    docker_version = client.version()
+    print("""
+    Docker API version: {api_version}
+        Docker version: {version}
+    """.format(api_version=docker_version['ApiVersion'],
+               version=docker_version['Version']))
+
+
+def start(c_name):
+    """Start a container and give it a name `c_name`"""
+    global client
+    # check if image exists otherwise download it
+    if not check_docker_image_exist(name=MANAGEIQ_IMAGE_NAME,
+                                    tag=MANAGEIQ_IMAGE_TAG):
+        pull_docker_image(name=MANAGEIQ_IMAGE_NAME,
+                          tag=MANAGEIQ_IMAGE_TAG)
+    else:
+        for image in client.images.list():
+            if image.id == MANAGEIQ_IMAGE_SHA256:
+                break
+
+    # run a new instance of ManageIQ container
+    print('Starting new container...')
+    global container
+    container = client.containers.run(
+        build_docker_image_id(name=MANAGEIQ_IMAGE_NAME, tag=MANAGEIQ_IMAGE_TAG),
+        privileged=True,
+        ports={'443/tcp': 8443},
+        detach=True,
+        name='{0}'.format(c_name if c_name is not None else 'miqcli_test')
+    )
+    print("Container started and it is detached.")
+
+
+def stop(c_name):
+    """Stop a container by name"""
+
+    global client
+    c_instance = None
+
+    for c in client.containers.list():
+        if c.name == c_name:
+            c_instance = c
+            break
+
+    if c_instance:
+        try:
+            print('Stopping container %s...' % c_instance.name)
+            c_instance.stop()
+            c_instance.remove()
+            print('Container stopped and deleted.')
+        except Exception as e:
+            print('Error stopping container \'%s\'.' % c_name)
+            print(e.message)
+            exit(1)
+    else:
+        print('Container \'%s\' not found!' % c_name)
+
+
+def wait_manageiq_start():
+    # check if ManageIQ instance is running
+    print("Waiting for ManageIQ to start up...")
+    max_retries = 20
+    retry = 0
+    while retry < max_retries:
+        headers = {'Accept': 'application/json'}
+        auth = requests.auth.HTTPBasicAuth('admin', 'smartvm')
+        r = None
+        try:
+            r = requests.get('https://localhost:8443/api',
+                             headers=headers, auth=auth, timeout=3.0, verify=False)
+        except requests.exceptions.Timeout:
+            pass
+        except requests.exceptions.ConnectionError:
+            pass
+        if r and r.status_code == 200:
+            print("Connected!")
+            break
+        retry += 1
+        time.sleep(5)
+    print("ManageIQ to started!")
+
+
+def main(args):
+    connect()
+    if args.command == 'start':
+        start(args.name)
+        wait_manageiq_start()
+    elif args.command == 'stop':
+        stop(args.name)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Script to manage testing container')
+
+    parser.add_argument('-c', action='store', dest='command',
+                        choices=['start', 'stop'], default='start',
+                        required=True, help='command to perform')
+
+    parser.add_argument('-n', action='store', dest='name',
+                        default='miqcli_test',
+                        help='container a name, default \'miqcli_test\'')
+
+    parsed_args = parser.parse_args()
+    main(parsed_args)

--- a/scripts/install_datastore.js
+++ b/scripts/install_datastore.js
@@ -1,0 +1,67 @@
+"use strict";
+var sys = require("system"),
+    page = require("webpage").create(),
+    MIQ_URL = "https://localhost:8443/";
+
+// page settings
+page.viewportSize = { width: 1920, height: 1080 };
+page.settings.userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.119 Safari/537.36';
+page.settings.javascriptEnabled = true;
+
+// phantomjs settings
+phantom.cookiesEnabled = true;
+phantom.javascriptEnabled = true;
+
+// load login page
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 1: Load '" + MIQ_URL + "'");
+  page.open(MIQ_URL);
+}, 5000);
+
+// input credentials
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 2: Login into the ManageIQ instance");
+  page.evaluate(function() {
+    document.querySelector("input[name='user_name']").value = "admin";
+    document.querySelector("input[name='user_password']").value = "smartvm";
+    $("#login").click();
+  });
+}, 10000);
+
+// go to the import/export automation page
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 3: Load 'https://localhost:8443/miq_ae_tools/import_export'");
+  page.open("https://localhost:8443/miq_ae_tools/import_export");
+}, 15000);
+
+// fill in the ManageIQ_CLI github project address and submit
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 4: Fill in manageiq_cli repository");
+  page.evaluate(function() {
+    document.querySelector("input[name='git_url']").value = "https://github.com/rhpit/manageiq-cli.git";
+    $("#git-url-import").click();
+  });
+}, 20000);
+
+// select default options for the github project branch
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 5: Submit branch (default for master)");
+  page.evaluate(function() {
+    $(".git-import-submit").click();
+  });
+}, 35000);
+
+// done
+setTimeout(function() {
+  console.log("");
+  console.log("### STEP 6: Close page and shutdown");
+  page.close();
+  setTimeout(function(){
+      phantom.exit();
+  }, 100);
+}, 42000);

--- a/scripts/phantomjs-config.json
+++ b/scripts/phantomjs-config.json
@@ -1,0 +1,5 @@
+{
+  "ignoreSslErrors": true,
+  "maxDiskCacheSize": 1000,
+  "outputEncoding": "utf8"
+}

--- a/scripts/testinstance
+++ b/scripts/testinstance
@@ -7,10 +7,10 @@
 # for the oficial image is 'admin' and the password is 'smartvm'
 #
 # To start a container:
-# $ scripts/init_testenv -c start [-n <container_name>]
+# $ scripts/testinstance -c start [-n <container_name>]
 #
 # To stop and remove the container:
-# $ scripts/init_testenv -c stop [-n <container_name>]
+# $ scripts/testinstance -c stop [-n <container_name>]
 #
 # WARNING: this script can delete a running container in your
 # system if you specify the name of this container with the

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py36,py27,pep8,docs
+envlist = py36,py27,pep8
 
 [testenv]
 usedevelop = True
@@ -20,6 +20,18 @@ commands = python setup.py build_sphinx
 [testenv:cover]
 commands =
   python setup.py test --coverage
+
+[testenv:integration]
+setenv =
+    VIRTUAL_ENV={envdir}
+    CLIENT_NAME=miqcli
+deps =
+    -r{toxinidir}/test-requirements.txt
+    docker>=2.7.0
+commands =
+    {toxinidir}/scripts/init_testenv -c start -n miqcli_testenv
+    python setup.py test
+    {toxinidir}/scripts/init_testenv -c stop -n miqcli_testenv
 
 [flake8]
 # F401 module import but unused, needed for python 2/3 compatibility

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
 minversion = 2.0
-envlist = py36,py27,pep8
+envlist = py36,py27,pep8,docs
 
 [testenv]
 usedevelop = True
-whitelist_externals = bash
+whitelist_externals = 
+    bash
+    sleep
+    phantomjs
 setenv =
     VIRTUAL_ENV={envdir}
     CLIENT_NAME=miqcli
@@ -29,14 +32,17 @@ deps =
     -r{toxinidir}/test-requirements.txt
     docker>=2.7.0
 commands =
-    {toxinidir}/scripts/init_testenv -c start -n miqcli_testenv
+    {toxinidir}/scripts/testinstance -c start -n miqcli_testenv
+    sleep 40
+    phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/change_configuration.js
+    phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/install_datastore.js
     python setup.py test
-    {toxinidir}/scripts/init_testenv -c stop -n miqcli_testenv
+    {toxinidir}/scripts/testinstance -c stop -n miqcli_testenv
 
 [flake8]
 # F401 module import but unused, needed for python 2/3 compatibility
 # H904 "Wrap lines in parentheses and not a backslash for line continuation
 # Removed in current hacking (https://review.openstack.org/#/c/101701/).
 ignore = F401,H803,H904
-exclude = .venv,.tox,dist,doc,*.egg,build
+exclude = .venv,.tox,dist,doc,*.egg,build,scripts
 show-source = true


### PR DESCRIPTION
This commit adds few scripts that are part of the CI automation #40 that we want
create for this project. The scripts are:

* testinstance - which is a python script to download ManageIQ docker image, start
and stop a ManageIQ instance. (requires Docker and python Docker library)

* change_configuration.js - PhantomJS script that will configure the local ManageIQ
instance to prepare it for testing purpose. For this commit only changing the switch
for git owner is set to allow us to upload our datastore. (requires PhantomJS)

* install_datastore.js - PhantomJS script that will import our datastore within the local
ManageIQ instance. (requires PhantomJS)

The file phantomjs-config.json is a simple configuration for PhantomJS to ignore
SSL errors (when a local ManageIQ container runs, its certificate is not valid. This
will cause the PhantomJS scripts to fail.