### PR TITLE
fix recursion error from being raised when getting action attribute

### DIFF
--- a/miqcli/decorators.py
+++ b/miqcli/decorators.py
@@ -61,7 +61,7 @@ def client_api(method):
         try:
             setattr(args[0], 'action', getattr(
                 _collection.action, method.__name__))
-        except AttributeError:
+        except (AttributeError, RecursionError):
             # action does not exist
             setattr(args[0], 'action', None)
 

--- a/miqcli/decorators.py
+++ b/miqcli/decorators.py
@@ -61,7 +61,7 @@ def client_api(method):
         try:
             setattr(args[0], 'action', getattr(
                 _collection.action, method.__name__))
-        except (AttributeError, RecursionError):
+        except (AttributeError, RuntimeError):
             # action does not exist
             setattr(args[0], 'action', None)
 


### PR DESCRIPTION
This commit handles the recursion error raised by the api client
library when a collection action is not found.

Closes #89 

A patch has been submitted to handle the error on the api library the client uses.