### PR TITLE
add provider class for easy id lookup thats transparent of the provider

### DIFF
--- a/example/os_provision_example.py
+++ b/example/os_provision_example.py
@@ -36,16 +36,17 @@ with open(payload_file) as f:
 # 2. the script will first make an automate request to get a floating ip
 # (cli call to automate get_floating_ip) this call returns an id to watch
 client.collection = "automation_requests"
-id = client.collection.create(str(payload_data), None, type='gen_floating_ip')
-print(id)
+req_id = client.collection.create(
+    method='gen_floating_ip', payload=str(payload_data), payload_file=None)
+print(req_id)
 
 
 # 3. the script will keep querying automate_request for the status to be
 #  finished, once finished, it will query for the floating ip id. If there was
 #  an error, the script will display the error message and exit.
 done = False
-while(not done):
-    result = client.collection.status(id)
+while not done:
+    result = client.collection.status(req_id)
     if result.request_state == "finished":
         done = True
     sleep(5)
@@ -76,16 +77,16 @@ print("updated payload data w/floating ip: {0}".format(payload_data))
 # 5. call the provision request to create this vm (cli call to
 #  provision_request create --provider OpenStack this will return an id
 client.collection = 'provision_requests'
-id = client.collection.create('OpenStack', str(payload_data), "")
-print("ID of the provision request: {0}".format(id))
+req_id = client.collection.create('OpenStack', str(payload_data), "")
+print("ID of the provision request: {0}".format(req_id))
 
 
 # 6. the script will keep querying the provision_request task for the status
 #  to be finished, once finished, it will return information about the
 #  provisioned machine or display the error message
 done = False
-while(not done):
-    result = client.collection.status(id)
+while not done:
+    result = client.collection.status(req_id)
     if result.request_state == "finished":
         done = True
     sleep(5)

--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -14,89 +14,79 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from collections import OrderedDict
-
 import click
+from collections import OrderedDict
 from manageiq_client.api import APIException
 
-from miqcli.constants import OSP_FIP_PAYLOAD, OSP_NETWORK_TYPE, OSP_TYPE
+from miqcli.constants import OSP_FIP_PAYLOAD, SUPPORTED_AUTOMATE_REQUESTS
 from miqcli.decorators import client_api
+from miqcli.provider import Networks, Tenant
 from miqcli.utils import log, get_input_data
 
 
 class Collections(object):
     """Automation requests collections."""
 
-    @click.option('--type', type=str,
-                  help='type of automation request')
+    @click.option('--method', type=click.Choice(SUPPORTED_AUTOMATE_REQUESTS),
+                  required=True, help='automation request method.')
     @click.option('--payload', type=str,
-                  help='payload data for an automation request')
+                  help='automation request payload data.')
     @click.option('--payload_file', type=str,
-                  help='file name of the payload data for an '
-                       'automation request')
+                  help='filename containing JSON formatted payload data for '
+                       'automation request.')
     @client_api
-    def create(self, payload, payload_file, type=None):
-        """
-        Create an automation request
+    def create(self, method, payload, payload_file,):
+        """Create an automation request
 
-        :param type: type of automation request
-        :param payload: dictionary in string format
+        ::
+        Builds the payload data for the request (performing all necessary id
+        lookups) and then submits the automation request to the server.
+
+        :param method: automation request to run
+        :type method: str
+        :param payload: json data in str format
+        :type payload: str
         :param payload_file: file location of the payload
-        :return: id of the automation request
+        :type payload_file: str
+        :return: automation request ID
+        :rtype: str
         """
+        _payload = None
+
         log.info("Attempt to create an automation request")
 
         # get the data from user input
         input_data = get_input_data(payload, payload_file)
 
-        if type is None:
-            # default behavior is just a passthrough of payload data
-            try:
-                outcome = self.action(input_data)
-                autoreq_id = outcome[0].id
-                return (autoreq_id)
-            except APIException as e:
-                log.abort("Exception occured creating an automation request:"
-                          " {0}".format(e))
-        if type == "gen_floating_ip":
+        # RFE: make generic as possible, remove conditional if possible
+        if method == SUPPORTED_AUTOMATE_REQUESTS[0]:
+            # generic request, default behavior passthrough payload data
+            _payload = input_data
+        elif method == SUPPORTED_AUTOMATE_REQUESTS[1]:
             # set the floating ip if set by the user
-            if "fip_pool" in input_data and input_data["fip_pool"]:
-
-                # lookup the cloud network
-                pub_cloudnetwork_id_list = self.api.adv_query_getattr(
-                    self.api.get_collection("cloud_networks"),
-                    [("name", "=", input_data["fip_pool"]), "&",
-                     ("type", "=", OSP_NETWORK_TYPE + "::CloudNetwork::Public")
-                     ], "id")
-
-                if len(pub_cloudnetwork_id_list) == 1:
-                    OSP_FIP_PAYLOAD["parameters"]["cloud_network_id"] = \
-                        pub_cloudnetwork_id_list[0]
-                else:
-                    log.abort("Querying for passed network: {0} failed".format(
-                        input_data["fip_pool"]))
+            if 'fip_pool' in input_data:
+                # lookup cloud network resource to get the id
+                # TODO: need to have user set the provider
+                networks = Networks('OpenStack', self.api, 'public')
+                OSP_FIP_PAYLOAD['parameters']['cloud_network_id'] = \
+                    networks.get_id(input_data['fip_pool'])
 
                 # lookup cloud tenant
-                cloudtenant_id_list = self.api.adv_query_getattr(
-                    self.api.get_collection("cloud_tenants"),
-                    [("name", "=", input_data["tenant"]), "&",
-                     ("type", "=", OSP_TYPE + "::CloudTenant")],
-                    "id")
+                # TODO: need to have user set the provider
+                tenant = Tenant('OpenStack', self.api)
+                OSP_FIP_PAYLOAD['parameters']['cloud_tenant_id'] = \
+                    tenant.get_id(input_data['tenant'])
 
-                if len(cloudtenant_id_list) == 1:
-                    OSP_FIP_PAYLOAD["parameters"]["cloud_tenant_id"] = \
-                        cloudtenant_id_list[0]
-                else:
-                    log.abort("Querying for cloud tenant: {0} failed".format(
-                        input_data["tenant"]))
+            _payload = OSP_FIP_PAYLOAD
 
-                outcome = self.action(OSP_FIP_PAYLOAD)
-                autoreq_id = outcome[0].id
-                log.info("Automation request to generate a floating ip "
-                         "created: {0}".format(autoreq_id))
-                return(autoreq_id)
-        else:
-            log.abort("Invalid automation request: {0}".format(type))
+        try:
+            # BUG: #93
+            outcome = self.action(_payload)
+            req_id = outcome[0].id
+            log.info('Automation request created: %s.' % req_id)
+            return req_id
+        except APIException as ex:
+            log.abort('Unable to create automation request: %s' % ex)
 
     @client_api
     def approve(self):
@@ -108,46 +98,59 @@ class Collections(object):
         """Deny."""
         raise NotImplementedError
 
-    @click.option('--id', type=str,
-                  help='id of a specific automation request')
+    @click.argument('req_id', metavar='ID', type=str, default='')
     @client_api
-    def status(self, id):
-        """
-        Get the status of automation requests.
-        :param id: id of the specific automation request
-        :return: shows status and returns the automation_request obj.
-        """
+    def status(self, req_id):
+        """Print the status for a automation request.
 
+        ::
+        Handles getting information for an existing automation request and
+        displaying/returning back to the user.
+
+        :param req_id: id of the automation request
+        :type req_id: str
+        :return: automation request object or list of automation request
+            objects
+        """
         status = OrderedDict()
-        if id:
-            automate_req_list = self.api.basic_query(self.collection,
-                                                     ("id", "=", id))
-            if len(automate_req_list) == 1:
-                req = automate_req_list[0]
-                status["state"] = req.request_state
-                status["status"] = req.status
-                status["message"] = req.message
-                click.echo("STATUS of automation request {0}".format(id))
-                for key in status:
-                    click.echo("{0}: {1}".format(key, status[key]))
-                return req
-            else:
-                log.abort("Unable to find an automation request with id: "
-                          "{0}".format(id))
-                return None
-        else:
-            click.echo("STATUS of all active automation requests:")
-            automation_req_list = self.api.basic_query(
-                self.collection,
-                ("request_state", "!=", "finished"))
 
-            if automation_req_list:
-                for auto_req in automation_req_list:
-                    click.echo("ID: {0}\tInstance: {1}\tSTATE: {2}\t STATUS:"
-                               " {3}".format(auto_req.id,
-                                             auto_req.options,
-                                             auto_req.request_state,
-                                             auto_req.status))
-            else:
-                click.echo("No active provisioning requests")
-            return(automation_req_list)
+        if req_id:
+            automation_requests = self.api.basic_query(
+                self.collection, ("id", "=", req_id))
+
+            if len(automation_requests) < 1:
+                log.warning('Automation request id: %s not found!' % req_id)
+                return
+
+            req = automation_requests[0]
+            status['state'] = req.request_state
+            status['status'] = req.status
+            status['message'] = req.message
+            log.info('-' * 50)
+            log.info('Automation request'.center(50))
+            log.info('-' * 50)
+            log.info(' * ID: %s' % req_id)
+            for key, value in status.items():
+                log.info(' * %s: %s' % (key.upper(), value))
+            log.info('-' * 50)
+
+            return req
+        else:
+            automation_requests = self.api.basic_query(
+                self.collection, ("request_state", "!=", "finished"))
+
+            if len(automation_requests) < 1:
+                log.warning('No active automation requests at this time.')
+                return None
+
+            log.info('-' * 50)
+            log.info(' Active automation requests'.center(50))
+            log.info('-' * 50)
+
+            for item in automation_requests:
+                log.info(' * ID: %s\tINSTANCE: %s\t STATE: %s\t STATUS: %s' %
+                         (item.id, item.options, item.request_state,
+                          item.status))
+            log.info('-' * 50)
+
+            return automation_requests

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -63,9 +63,7 @@ DEFAULT_CONFIG = {
     'enable_ssl_verify': False
 }
 
-OSP_TYPE = "ManageIQ::Providers::Openstack::CloudManager"
-OSP_NETWORK_TYPE = "ManageIQ::Providers::Openstack::NetworkManager"
-
+SUPPORTED_AUTOMATE_REQUESTS = ['generic', 'gen_floating_ip']
 SUPPORTED_PROVIDERS = ["OpenStack"]
 REQUIRED_OSP_KEYS = ["email", "tenant", "image", "security_group", "network",
                      "flavor", "key_pair", "vm_name"]

--- a/miqcli/provider.py
+++ b/miqcli/provider.py
@@ -1,0 +1,293 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from manageiq_client.api import APIException
+from manageiq_client.filters import Q
+
+from miqcli.utils import log
+
+__all__ = ['Flavors', 'Templates', 'SecurityGroups', 'KeyPair', 'Tenant',
+           'Networks']
+
+
+class Provider(object):
+    """Cloud provider parent class.
+
+    Cloud provider component 'child' classes all inherit this class. It
+    provides provider component classes with data they need..
+    """
+
+    __collection_name__ = ''
+
+    # declare attributes to be defined at a later time..
+    _type, _cloud_type, _network_type = '', '', ''
+    _collection = None
+
+    def __init__(self, name, api):
+        """Constructor.
+
+        :param name: provider name
+        :type name: str
+        :param api: client api pointer
+        :type api: class
+        """
+        self._name = name
+        self._api = api
+
+        # lets first save the provider types for cloud & network
+        for res in self._api.client.collections.providers.all:
+            if self._name.lower().title() in res.type:
+                if 'cloud' in res.type.lower():
+                    self._cloud_type = res.type
+                elif 'network' in res.type.lower():
+                    self._network_type = res.type
+
+    @property
+    def name(self):
+        """Provider name property.
+
+        :return: provider name
+        :rtype: str
+        """
+        return self._name
+
+    @property
+    def api(self):
+        """Client API pointer property.
+
+        :return: client api pointer
+        :rtype: class
+        """
+        return self._api
+
+    @property
+    def type(self):
+        """Resource type property.
+
+        :return: resource type
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, value):
+        """Set the resource type.
+
+        :param value: resource name
+        :type value: str
+        """
+        self._type = value
+
+    @property
+    def cloud_type(self):
+        """Cloud type property.
+
+        :return: resource cloud type
+        :rtype: str
+        """
+        return self._cloud_type
+
+    @property
+    def network_type(self):
+        """Network type property.
+
+        :return: resource network type
+        :rtype: str
+        """
+        return self._network_type
+
+    @property
+    def collection(self):
+        """Runtime collection property.
+
+        This property contains the collection that is being used.
+
+        :return: collection
+        :rtype: class
+        """
+        return self._collection
+
+    @collection.setter
+    def collection(self, value):
+        """Set the collection object.
+
+        :param value: collection name
+        :type value: str
+        """
+        self._collection = getattr(self.api.client.collections, value)
+
+    def get_resource(self, name):
+        """Get the resource based on the name given.
+
+        :param name: resource name
+        :type name: str
+        :return: resource or none
+        :rtype: dict or None
+        """
+        output = None
+        query = Q('name', '=', name) & Q('type', '=', self.type)
+
+        try:
+            output = self.collection.filter(query)
+        except (APIException, ValueError):
+            log.debug("Invalid query attempted {0} for """
+                      "{1}".format(query, self.__collection_name__))
+
+        if len(output.resources) == 1:
+            resource = output.resources[0]
+        elif len(output.resources) > 1:
+            log.warning('Multiple resources match %s:%s.' % (
+                self.__collection_name__, name))
+            # RFE: handle multiple resources with same name/provider
+            # this should be very unlikely that we get multiples, for now we
+            # will return first match
+            resource = output.resources[0]
+        else:
+            resource = None
+        return resource
+
+    def get_id(self, name):
+        """Get the ID for the resource name.
+
+        :param name: resource name
+        :type name: str
+        :return: resource id
+        :rtype: int
+        """
+        return self.get_resource(name)['id']
+
+
+class Flavors(Provider):
+    """Provider flavor component."""
+
+    __collection_name__ = 'flavors'
+
+    def __init__(self, name, api):
+        """Constructor."""
+        super(Flavors, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.cloud_type + '::Flavor'
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(Flavors, self).get_resource(name)
+        if val is None:
+            log.abort('Flavor %s not found for provider %s.' %
+                      (name, self.name))
+        return val
+
+
+class Templates(Provider):
+    """Provider images component."""
+
+    __collection_name__ = 'templates'
+
+    def __init__(self, name, api):
+        """Constructor."""
+        super(Templates, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.cloud_type + '::Template'
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(Templates, self).get_resource(name)
+        if val is None:
+            log.abort('Template %s not found for provider %s.' %
+                      (name, self.name))
+        return val
+
+    def get_id(self, name):
+        """Override the parent get_id."""
+        return self.get_resource(name)['guid']
+
+
+class SecurityGroups(Provider):
+    """Provider security group component."""
+
+    __collection_name__ = 'security_groups'
+
+    def __init__(self, name, api):
+        """Constructor."""
+        super(SecurityGroups, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.network_type + '::SecurityGroup'
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(SecurityGroups, self).get_resource(name)
+        if val is None:
+            log.abort('Security group %s not found for provider %s.' %
+                      (name, self.name))
+        return val
+
+
+class KeyPair(Provider):
+    """Provider key pair component."""
+
+    __collection_name__ = 'authentications'
+
+    def __init__(self, name, api):
+        super(KeyPair, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.cloud_type + '::AuthKeyPair'
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(KeyPair, self).get_resource(name)
+        if val is None:
+            log.abort('Key pair %s not found for provider %s.' %
+                      (name, self.name))
+        return val
+
+
+class Tenant(Provider):
+    """Provider tenant component."""
+
+    __collection_name__ = 'cloud_tenants'
+
+    def __init__(self, name, api):
+        """Constructor."""
+        super(Tenant, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.cloud_type + '::CloudTenant'
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(Tenant, self).get_resource(name)
+        if val is None:
+            log.abort('Tenant %s not found for provider %s.' %
+                      (name, self.name))
+        return val
+
+
+class Networks(Provider):
+    """Provider network component."""
+
+    __collection_name__ = 'cloud_networks'
+
+    def __init__(self, name, api, network):
+        """Constructor."""
+        super(Networks, self).__init__(name, api)
+        self.collection = self.__collection_name__
+        self.type = self.network_type + '::CloudNetwork::' + network.title()
+
+    def get_resource(self, name):
+        """Override the parent get_resource."""
+        val = super(Networks, self).get_resource(name)
+        if val is None:
+            log.abort('Network %s not found for provider %s.' %
+                      (name, self.name))
+        return val

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -28,7 +28,8 @@ from miqcli.utils import log
 
 __all__ = ['Config', 'get_class_methods', 'get_client_api_pointer',
            'is_default_config_used', 'display_commands',
-           '_abort_invalid_commands', 'get_collection_class']
+           '_abort_invalid_commands', 'get_collection_class',
+           'get_input_data']
 
 
 class Config(dict):


### PR DESCRIPTION
This commit adds a new module containing classes regarding components
for a provider. Collections can easily create a provider object and
perform lookups on a string element to return the given id in manageiq.
The class will automatically determine the resource type to filter on.
Removing the need to have static strings in a collection class.

It also includes the following:
  * modifications to automation/provision requests collections to use
  the new provider class.

  * cosmetic changes to automation/provision requests collections.

  * automation/provision requests status previously accepted the id by
  a click option. Switched to a argument. This way users do not need to
  define the --id and can just give the id. This command only needs the
  id so it makes sense to be positional. Also removes use of built-in
  as a variable.

Closes #86