### PR TITLE
perform clean up to the existing query methods

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -17,7 +17,6 @@
 import os
 import urllib3
 import errno
-import inspect
 
 from click import Context
 from click.globals import push_context
@@ -26,7 +25,6 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from manageiq_client.api import APIException, ManageIQClient
-from manageiq_client.filters import Q
 
 from requests.exceptions import ConnectionError
 
@@ -229,158 +227,6 @@ class ClientAPI(object):
             log.abort('Error creating library pointer - {0}'.format(e.message))
         except Exception as e:
             log.abort('{0}'.format(e.message))
-
-    def get_name(self):
-        """
-        get the name of the collection module
-        :return: name of the collection
-        """
-        mod_stack = inspect.stack()[2]
-        module = inspect.getmodule(mod_stack[0])
-        return module.__name__.split(".")[-1]
-
-    def get_collection(self, collection_name=None):
-        """
-        get the collection object given the name
-        :param collection_name: name of the collection
-        :return: collection object
-        """
-        if collection_name:
-            try:
-                return getattr(self.client.collections, collection_name)
-            except AttributeError:
-                log.warning("Collection {0} does not exist.".format(
-                    collection_name)
-                )
-                return None
-        else:
-            name = self.get_name()
-            return getattr(self.client.collections, name)
-
-    def query_getattr(self, collection, query, attr):
-        """
-        perform a basic query, and return the object's attribute that
-        is passed in.
-
-        :param collection: the specific collection object
-        :param query: query (a single tuple)
-        :param attr: the attribute to get
-        :return: returns a list of attributes, [] if query returns nothing.
-        """
-        collect_list = self.basic_query(collection, query)
-        if len(collect_list) == 0:
-            return None
-        elif len(collect_list) == 1:
-            try:
-                return getattr(collect_list[0], attr)
-            except AttributeError as e:
-                log.warning(e)
-                return None
-        else:
-            attr_list = []
-            for collection in collect_list:
-                try:
-                    attr_list.append(getattr(collection, attr))
-                except AttributeError as e:
-                    log.warning(e)
-                    return None
-            return attr_list
-
-    def adv_query_getattr(self, collection, query_list, attr):
-        """
-        perform an advanced query, and return a list of each obj's attribute.
-
-        :param collection: the specific collection object
-        :param query_list: a list of tuple queries joined, and operators (&,|)
-        :param attr: the attribute to get
-        :return: returns a list of attributes, [] if query returns nothing.
-        """
-        attr_list = []
-        collect_list = self.advanced_query(collection, query_list)
-        if len(collect_list) == 0:
-            return collect_list
-        else:
-            for collection in collect_list:
-                try:
-                    attr_list.append(getattr(collection, attr))
-                except AttributeError as e:
-                    log.warning(e)
-                    return []
-            return attr_list
-
-    def basic_query(self, collection, query):
-        """
-        basic query of a collection object
-
-        Example of the input
-        vms, ("name","=","cbn_eap64openjdk17c6_pkcrx")
-
-        :param collection: the specific collection object
-        :param query: tuple of name, operand, value
-        :return: a list of collections from the query
-                 (Empty if none or invalid)
-        """
-        if not collection:
-            log.abort("Invalid collection passed to be queried")
-        try:
-            if (len(query) == 3):
-                return collection.filter(
-                    Q(query[0], query[1], query[2])
-                ).resources
-            else:
-                log.warning("Invalid query: {0}".format(query))
-                return([])
-        # ValueError caught for invalid operators used
-        except (APIException, ValueError) as e:
-            log.warning("Invalid Query attempted: {0}, Error: {1}".format(
-                query, e)
-            )
-            return ([])
-
-    def advanced_query(self, collection, query_list):
-        """
-        Advance query of a collection object, which just means it is
-        a chain of multiple queries with the & or | operands.
-
-        Example of the input:
-        "vms", [("name","=","cbn_eap64openjdk17c6_pkcrx"),
-        '|', ("id",">",9999934)]
-
-        :param collection: the specific collection object
-        :param query_list: list of (name, operand, value) tuples and operands
-        :return: a list of resources
-        """
-        if not collection:
-            log.abort("Invalid collection passed to be queried")
-        query = ""
-        if len(query_list) % 2 == 0:
-            # warning message, invalid query was attempted <query_dict>
-            log.warning("Invalid query attempted {0}".format(query_list))
-            return ([])
-        while (query_list):
-            query_tuple = query_list.pop(0)
-            # verify the querying tuple has 3 vals set (name, operator, value)
-            if (len(query_tuple) == 3):
-                query += str("Q('" + str(query_tuple[0]) + "', '" +
-                             str(query_tuple[1])) + "', '" + \
-                    str(query_tuple[2]) + "')"
-            else:
-                log.warning("Invalid query: {0}".format(query_tuple))
-                return([])
-            if query_list:
-                query += " {} ".format(query_list.pop(0))
-            else:
-                try:
-                    resources = collection.filter(
-                        eval(query)
-                    ).resources
-                except (APIException, ValueError, TypeError) as e:
-                    # most likely user passed an invalid attribute name
-                    error = "Invalid Query attempted: {0}, Error: " \
-                            "{1}".format(query, e)
-                    log.warning(error)
-                    return ([])
-                return resources
 
 
 class Client(object):

--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -21,6 +21,7 @@ from manageiq_client.api import APIException
 from miqcli.constants import OSP_FIP_PAYLOAD, SUPPORTED_AUTOMATE_REQUESTS
 from miqcli.decorators import client_api
 from miqcli.provider import Networks, Tenant
+from miqcli.query import BasicQuery
 from miqcli.utils import log, get_input_data
 
 
@@ -113,10 +114,10 @@ class Collections(object):
             objects
         """
         status = OrderedDict()
+        query = BasicQuery(self.collection)
 
         if req_id:
-            automation_requests = self.api.basic_query(
-                self.collection, ("id", "=", req_id))
+            automation_requests = query(("id", "=", req_id))
 
             if len(automation_requests) < 1:
                 log.warning('Automation request id: %s not found!' % req_id)
@@ -136,8 +137,7 @@ class Collections(object):
 
             return req
         else:
-            automation_requests = self.api.basic_query(
-                self.collection, ("request_state", "!=", "finished"))
+            automation_requests = query(("request_state", "!=", "finished"))
 
             if len(automation_requests) < 1:
                 log.warning('No active automation requests at this time.')

--- a/miqcli/collections/provision_requests.py
+++ b/miqcli/collections/provision_requests.py
@@ -24,6 +24,7 @@ from miqcli.constants import SUPPORTED_PROVIDERS, REQUIRED_OSP_KEYS, \
 from miqcli.decorators import client_api
 from miqcli.provider import Flavors, KeyPair, Networks, SecurityGroups,\
     Templates, Tenant
+from miqcli.query import BasicQuery
 from miqcli.utils import log, get_input_data
 
 
@@ -151,10 +152,10 @@ class Collections(object):
         :return: provision request object or list of provision request objects
         """
         status = OrderedDict()
+        query = BasicQuery(self.collection)
 
         if req_id:
-            provision_requests = self.api.basic_query(
-                self.collection, ("id", "=", req_id))
+            provision_requests = query(("id", "=", req_id))
 
             if len(provision_requests) < 1:
                 log.warning('Provision request id: %s not found!' % req_id)
@@ -175,9 +176,7 @@ class Collections(object):
 
             return req
         else:
-            provision_requests = self.api.basic_query(
-                self.collection, ("request_state", "!=", "finished")
-            )
+            provision_requests = query(("request_state", "!=", "finished"))
 
             if len(provision_requests) < 1:
                 log.warning(' * No active provision requests at this time')

--- a/miqcli/query.py
+++ b/miqcli/query.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2017 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from manageiq_client.api import APIException
+from manageiq_client.filters import Q
+
+from miqcli.utils import log
+
+__all__ = ['BasicQuery', 'AdvancedQuery']
+
+
+class BaseQuery(object):
+    """Base query.
+
+    This class contains default methods each child query class can use.
+    """
+
+    def __init__(self, collection):
+        """Constructor.
+
+        :param collection: collection object
+        :type collection: object
+        """
+        self.collection = collection
+        self.resources = list()
+
+    def __getattr__(self, attr):
+        """Return the value for the given attribute.
+
+        :param attr: attribute name
+        :type attr: str
+        :return: attribute value
+        """
+        if len(self.resources) == 0:
+            raise AttributeError('No available resources. Did you perform '
+                                 'a query?')
+        elif len(self.resources) == 1:
+            # load attributes into entity object
+            self.resources[0].reload()
+
+            if attr not in self.resources[0].__dict__:
+                raise AttributeError('No such attribute {0}'.format(attr))
+            return self.resources[0].__dict__[attr]
+        else:
+            raise AttributeError('Cannot get attribute when multiple '
+                                 'resources exist.')
+
+
+class BasicQuery(BaseQuery):
+    """Basic query.
+
+    This class will perform a basic query on the given collection.
+    """
+
+    def __init__(self, collection):
+        """Constructor.
+
+        :param collection: collection object
+        :type collection: object
+        """
+        super(BasicQuery, self).__init__(collection)
+
+    def __call__(self, query):
+        """Performs a basic query on a collection.
+
+        :param query: query containing name, operand and value
+        :type query: tuple
+        :return: collection resources matching the supplied query
+        :rtype: list
+
+        Usage:
+
+        .. code-block: python
+
+            # query vms collection to find the following vm by name
+            query = BasicQuery(vm_collection)
+            query(('name', '=', 'vm_foo'))
+            # -- or --
+            query.__call__(('name', '=', 'vm_foo'))
+        """
+        if len(query) != 3:
+            log.warning('Query must contain three indexes. i.e. '
+                        '(name, operand, value)')
+            return self.resources
+
+        try:
+            resources = getattr(self.collection, 'filter')(
+                Q(query[0], query[1], query[2])
+            )
+            self.resources = resources.resources
+        except (APIException, ValueError) as e:
+            log.error('Query attempted failed: {0}, error: {1}'.format(
+                query, e))
+        return self.resources
+
+
+class AdvancedQuery(BaseQuery):
+    """Advanced query.
+
+    This class will perform a advanced query on the given collection
+    """
+
+    def __init__(self, collection):
+        """Constructor.
+
+        :param collection: collection object
+        :type collection: object
+        """
+        super(AdvancedQuery, self).__init__(collection)
+
+    def __call__(self, query):
+        """Performs a advanced query on a collection.
+
+        :param query: multiple queries containing name, operand and value
+        :type query: list
+        :return: collection resources matching the supplied query
+        :rtype: list
+
+        Usage:
+
+        .. code-block: python
+
+        query = AdvancedQuery(vm_collection)
+        query([('name', '=', 'vm_foo'), '&', ('id', '>', '9999934')])
+        # -- or --
+        query.__call__([('name', '=', 'vm_foo'), '&', ('id', '>', '9999934')])
+        """
+        adv_query = ''
+
+        if len(query) % 2 == 0:
+            log.warning('Query attempted is invalid: {0}'.format(query))
+            return self.resources
+
+        # build query in string form
+        while query:
+            _query = query.pop(0)
+
+            if isinstance(_query, tuple) and len(_query) != 3:
+                log.warning('Query must contain three indexes (name, operator,'
+                            ' value)')
+                return self.resources
+            elif isinstance(_query, tuple):
+                adv_query += str("Q('" + str(_query[0]) + "', '" + str(
+                    _query[1])) + "', '" + str(_query[2]) + "')"
+            elif isinstance(_query, str):
+                adv_query += ' {0} '.format(_query)
+
+        try:
+            resources = getattr(self.collection, 'filter')(eval(adv_query))
+            self.resources = resources.resources
+        except (APIException, ValueError, TypeError) as e:
+            # most likely user passed an invalid attribute name
+            log.error('Query attempted failed: {0}, error: {1}'.format(
+                query, e))
+        return self.resources


### PR DESCRIPTION
This commit mostly consists of clean up for the current available
query methods. A new module has been created named query. Which
contains two new classes: BasicQuery and AdvancedQuery. Each class
accepts a miq api collection object as input. You can then call
the instance as a function providing the query. Each query will
return back a list of entity objects. Each class getattr method
will return back the value for the attribute given within the
entity object queried.

It also updates the provider class to use the advanced query
instead of directly calling the collection filter method. This
way we can be consistent across the code.

i.e.
```python
from miqcli.query import BasicQuery, AdvancedQuery

query = BasicQuery(flavor_collection)
resources = query(('name', '=', 'flavor')

query = AdvancedQuery(flavor_collection)
resources = query([('name', '=', 'flavor'), '&', ('id', '>', '1')])
```