### PR TITLE
rename constant AUTHDIR

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -28,7 +28,7 @@ from manageiq_client.api import APIException, ManageIQClient
 
 from requests.exceptions import ConnectionError
 
-from miqcli.constants import AUTHDIR, DEFAULT_CONFIG
+from miqcli.constants import TOKENFILE, DEFAULT_CONFIG
 from miqcli.utils import log, get_collection_class
 
 __all__ = ['ClientAPI', 'Client']
@@ -57,7 +57,7 @@ class ClientAPI(object):
 
         # create miqcli folder if it doesn't exist
         try:
-            os.makedirs(os.path.dirname(AUTHDIR))
+            os.makedirs(os.path.dirname(TOKENFILE))
         except OSError as e:
             if e.errno != errno.EEXIST:
                 log.abort('Error creating user miqcli folder.')
@@ -142,11 +142,11 @@ class ClientAPI(object):
     @staticmethod
     def _set_auth_file(token):
         """
-        Save the token into AUTHDIR
+        Save the token into TOKENFILE
         :param token: given token
         """
         try:
-            with open(AUTHDIR, "w") as fp:
+            with open(TOKENFILE, "w") as fp:
                 fp.write(token)
         except OSError as e:
             log.abort('Error setting token file. %s' % e)
@@ -154,10 +154,10 @@ class ClientAPI(object):
     @staticmethod
     def _get_from_auth_file():
         """
-        Get the token from the auth file (AUTHDIR)
+        Get the token from the token file (TOKENFILE)
         """
         try:
-            with open(AUTHDIR, "r") as fp:
+            with open(TOKENFILE, "r") as fp:
                 token = fp.read().strip()
         except IOError as e:
             if e.errno != errno.ENOENT:

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -69,8 +69,8 @@ REQUIRED_OSP_KEYS = ["email", "tenant", "image", "security_group", "network",
                      "flavor", "key_pair", "vm_name"]
 OPTIONAL_OSP_KEYS = ["fip_pool"]
 
-#: filesystem root for miqcli authentication store
-AUTHDIR = os.path.join(os.path.expanduser('~'), ".miqcli/auth")
+#: token file used to authenticate into ManageIQ
+TOKENFILE = os.path.join(os.path.expanduser('~'), ".miqcli/token")
 
 OSP_PAYLOAD = {
     "template_fields": {


### PR DESCRIPTION
The semantic of AUTHDIR does not relates to what the constant holds,
which is the file that records the token. So, TOKENFILE seems to be a
better name for that constant.