### PR TITLE
improve exception handling for api.ClientAPI._set_auth_file

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -148,7 +148,7 @@ class ClientAPI(object):
         try:
             with open(TOKENFILE, "w") as fp:
                 fp.write(token)
-        except OSError as e:
+        except (IOError, OSError) as e:
             log.abort('Error setting token file. %s' % e)
 
     @staticmethod


### PR DESCRIPTION
There are some times where IOError can also be thrown. For instance
if the user running the CLI has no permission to open TOKENFILE.