### PR TITLE
make openstack example script python 3 compatible

### DIFF
--- a/example/os_provision_example.py
+++ b/example/os_provision_example.py
@@ -64,7 +64,8 @@ else:
     raise SystemExit(1)
 return_dict = ast.literal_eval(return_data)
 if return_dict["status"] == "success":
-    fip, fip_id = return_dict["return"].items()[0]
+    fip = next(iter(return_dict['return']))
+    fip_id = return_dict['return'][fip]
     print("got floating ip: {0}: {1}".format(fip, fip_id))
 else:
     print("error occurred: {0}".format(


### PR DESCRIPTION
This commit will fix a bug when trying to get the floating ip/id.
With python 3 calling .items() on a dictionary will not return a list
like python 2 does. It returns a view object. This patch updates the
script to handle getting the data for python2/3.