### PR TITLE
fix config load from yaml when the yaml file is wrong

### DIFF
--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -81,7 +81,7 @@ class Config(dict):
         except yaml.YAMLError as e:
             if self._verbose:
                 log.debug('Standard error: {0}'.format(e.sterror))
-                log.abort('Error in config {0}.'.format(_cfg_file))
+            log.abort('Error in config {0}.'.format(_cfg_file))
 
     def from_env(self, var):
         """Load configuration settings from environment variable.


### PR DESCRIPTION
From design, we want to load configuration from a yaml file. If the file
doesn't exist we want to silently carry on. But if the file exist and
there is an error in the file (i.e. yaml syntax), we want the client to
fail and let the user know that the failure occurred during
configuration loading. If verbose is turned ON, than a bit more
information will be shown.