### PR TITLE
fix parsing collection actions return data to get the request id

### DIFF
--- a/miqcli/collections/__init__.py
+++ b/miqcli/collections/__init__.py
@@ -13,3 +13,51 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+__all__ = ['CollectionsMixin']
+
+
+class CollectionsMixin(object):
+    """Mixin collections class.
+
+    Provides extra properties and methods to collections.
+    """
+
+    # request id
+    _req_id = ''
+
+    @property
+    def req_id(self):
+        """Request id property.
+
+        :return: request id
+        :rtype: str
+        """
+        return self._req_id
+
+    @req_id.setter
+    def req_id(self, value):
+        """Set the request id.
+
+        The ManageIQ API Client library's action calls returns its output
+        using the built-in 'map'. Python 2 map returns a list of results,
+        while Python 3 map returns the iterator itself. This property setter
+        handles getting the id.
+
+        Usage
+
+        .. code-block: python
+
+        self.req_id = self.action(<payload>)
+        log.info('Request ID: %s.' % self.req_id)
+
+        :param value: request id
+        :type value: iterator|list
+        """
+        try:
+            # python 3
+            results = next(value)
+        except TypeError:
+            # python 2
+            results = value.pop(0)
+        self._req_id = getattr(results, 'id')

--- a/miqcli/collections/actions.py
+++ b/miqcli/collections/actions.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Actions collections."""
 
     @client_api

--- a/miqcli/collections/alert_definitions.py
+++ b/miqcli/collections/alert_definitions.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Alert definitions collections."""
 
     @client_api

--- a/miqcli/collections/alerts.py
+++ b/miqcli/collections/alerts.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Alerts collections."""

--- a/miqcli/collections/arbitration_profiles.py
+++ b/miqcli/collections/arbitration_profiles.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Arbitration profiles collections."""
 
     @client_api

--- a/miqcli/collections/arbitration_rules.py
+++ b/miqcli/collections/arbitration_rules.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Arbitration rules collections."""
 
     @client_api

--- a/miqcli/collections/arbitration_settings.py
+++ b/miqcli/collections/arbitration_settings.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Arbitration settings collections."""
 
     @client_api

--- a/miqcli/collections/authentications.py
+++ b/miqcli/collections/authentications.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Authentications collections."""
 
     @client_api

--- a/miqcli/collections/automate.py
+++ b/miqcli/collections/automate.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Automate collections."""

--- a/miqcli/collections/automate_domains.py
+++ b/miqcli/collections/automate_domains.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Automate domains collections."""
 
     @client_api

--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -18,6 +18,7 @@ import click
 from collections import OrderedDict
 from manageiq_client.api import APIException
 
+from miqcli.collections import CollectionsMixin
 from miqcli.constants import OSP_FIP_PAYLOAD, SUPPORTED_AUTOMATE_REQUESTS
 from miqcli.decorators import client_api
 from miqcli.provider import Networks, Tenant
@@ -25,7 +26,7 @@ from miqcli.query import BasicQuery
 from miqcli.utils import log, get_input_data
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Automation requests collections."""
 
     @click.option('--method', type=click.Choice(SUPPORTED_AUTOMATE_REQUESTS),
@@ -81,11 +82,9 @@ class Collections(object):
             _payload = OSP_FIP_PAYLOAD
 
         try:
-            # BUG: #93
-            outcome = self.action(_payload)
-            req_id = outcome[0].id
-            log.info('Automation request created: %s.' % req_id)
-            return req_id
+            self.req_id = self.action(_payload)
+            log.info('Automation request created: %s.' % self.req_id)
+            return self.req_id
         except APIException as ex:
             log.abort('Unable to create automation request: %s' % ex)
 

--- a/miqcli/collections/availability_zones.py
+++ b/miqcli/collections/availability_zones.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Availability zones collections."""
 
     @client_api

--- a/miqcli/collections/blueprints.py
+++ b/miqcli/collections/blueprints.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Blueprints collections."""
 
     @client_api

--- a/miqcli/collections/categories.py
+++ b/miqcli/collections/categories.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Categories collections."""
 
     @client_api

--- a/miqcli/collections/chargebacks.py
+++ b/miqcli/collections/chargebacks.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Chargebacks collections."""
 
     @client_api

--- a/miqcli/collections/cloud_networks.py
+++ b/miqcli/collections/cloud_networks.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Cloud networks collections."""
 
     @client_api

--- a/miqcli/collections/cloud_tenants.py
+++ b/miqcli/collections/cloud_tenants.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Cloud tenants collections."""
 
     @client_api

--- a/miqcli/collections/cloud_volumes.py
+++ b/miqcli/collections/cloud_volumes.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Cloud volumes collections."""
 
     @client_api

--- a/miqcli/collections/clusters.py
+++ b/miqcli/collections/clusters.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Clusters collections."""
 
     @client_api

--- a/miqcli/collections/conditions.py
+++ b/miqcli/collections/conditions.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Conditions collections."""
 
     @client_api

--- a/miqcli/collections/configuration_script_payloads.py
+++ b/miqcli/collections/configuration_script_payloads.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Configuration script payloads collections."""

--- a/miqcli/collections/configuration_script_sources.py
+++ b/miqcli/collections/configuration_script_sources.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Configuration script sources collections."""
 
     @client_api

--- a/miqcli/collections/container_deployments.py
+++ b/miqcli/collections/container_deployments.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Container deployments collections."""
 
     @client_api

--- a/miqcli/collections/currencies.py
+++ b/miqcli/collections/currencies.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Currencies collections."""

--- a/miqcli/collections/data_stores.py
+++ b/miqcli/collections/data_stores.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Data stores collections."""
 
     @client_api

--- a/miqcli/collections/events.py
+++ b/miqcli/collections/events.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Events collections."""
 
     @client_api

--- a/miqcli/collections/features.py
+++ b/miqcli/collections/features.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Features collections."""

--- a/miqcli/collections/flavors.py
+++ b/miqcli/collections/flavors.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Flavors collections."""
 
     @client_api

--- a/miqcli/collections/groups.py
+++ b/miqcli/collections/groups.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Groups collections."""
 
     @client_api

--- a/miqcli/collections/hosts.py
+++ b/miqcli/collections/hosts.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Hosts collections."""
 
     @client_api

--- a/miqcli/collections/instances.py
+++ b/miqcli/collections/instances.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Instances collections."""
 
     @client_api

--- a/miqcli/collections/load_balancers.py
+++ b/miqcli/collections/load_balancers.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Load balancers collections."""
 
     @client_api

--- a/miqcli/collections/measures.py
+++ b/miqcli/collections/measures.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Measures collections."""

--- a/miqcli/collections/notifications.py
+++ b/miqcli/collections/notifications.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Notifications collections."""
 
     @client_api

--- a/miqcli/collections/orchestration_templates.py
+++ b/miqcli/collections/orchestration_templates.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Orchestration templates collections."""
 
     @client_api

--- a/miqcli/collections/pictures.py
+++ b/miqcli/collections/pictures.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Pictures collections."""
 
     @client_api

--- a/miqcli/collections/policies.py
+++ b/miqcli/collections/policies.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Policies collections."""
 
     @client_api

--- a/miqcli/collections/policy_actions.py
+++ b/miqcli/collections/policy_actions.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Policy actions collections."""
 
     @client_api

--- a/miqcli/collections/policy_profiles.py
+++ b/miqcli/collections/policy_profiles.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Policy profiles collections."""
 
     @client_api

--- a/miqcli/collections/providers.py
+++ b/miqcli/collections/providers.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Providers collections."""
 
     @client_api

--- a/miqcli/collections/provision_dialogs.py
+++ b/miqcli/collections/provision_dialogs.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Provision dialogs collections."""
 
     @client_api

--- a/miqcli/collections/provision_requests.py
+++ b/miqcli/collections/provision_requests.py
@@ -212,11 +212,9 @@ class Collections(CollectionsMixin):
 
             log.debug("Payload for the provisioning request: {0}".format(
                 pformat(AWS_PAYLOAD)))
-            outcome = self.action(AWS_PAYLOAD)
-            # BUG: #93
-            req_id = outcome[0].id
-            log.info("Provisioning request created: {0}".format(req_id))
-            return req_id
+            self.req_id = self.action(AWS_PAYLOAD)
+            log.info("Provisioning request created: {0}".format(self.req_id))
+            return self.req_id
 
     @client_api
     def deny(self):

--- a/miqcli/collections/provision_requests.py
+++ b/miqcli/collections/provision_requests.py
@@ -19,6 +19,7 @@ from pprint import pformat
 import click
 from collections import OrderedDict
 
+from miqcli.collections import CollectionsMixin
 from miqcli.constants import SUPPORTED_PROVIDERS, REQUIRED_OSP_KEYS, \
     OSP_PAYLOAD, REQUIRED_AWS_AUTO_PLACEMENT_KEYS, AWS_PAYLOAD, \
     REQUIRED_AWS_PLACEMENT_KEYS
@@ -29,7 +30,7 @@ from miqcli.query import BasicQuery
 from miqcli.utils import log, get_input_data
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Provision requests collections."""
 
     @client_api
@@ -123,11 +124,9 @@ class Collections(object):
 
             log.debug("Payload for the provisioning request: {0}".format(
                 pformat(OSP_PAYLOAD)))
-            outcome = self.action(OSP_PAYLOAD)
-            # BUG: #93
-            req_id = outcome[0].id
-            log.info("Provisioning request created: {0}".format(req_id))
-            return req_id
+            self.req_id = self.action(OSP_PAYLOAD)
+            log.info("Provisioning request created: {0}".format(self.req_id))
+            return self.req_id
 
         # RFE: make generic as possible, remove conditional per provider
         if provider == "Amazon":

--- a/miqcli/collections/rates.py
+++ b/miqcli/collections/rates.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Rates collections."""
 
     @client_api

--- a/miqcli/collections/regions.py
+++ b/miqcli/collections/regions.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Regions collections."""
 
     @client_api

--- a/miqcli/collections/reports.py
+++ b/miqcli/collections/reports.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Reports collections."""
 
     @client_api

--- a/miqcli/collections/request_tasks.py
+++ b/miqcli/collections/request_tasks.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Request tasks collections."""

--- a/miqcli/collections/requests.py
+++ b/miqcli/collections/requests.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Requests collections."""
 
     @client_api

--- a/miqcli/collections/resource_pools.py
+++ b/miqcli/collections/resource_pools.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Resource pools collections."""
 
     @client_api

--- a/miqcli/collections/results.py
+++ b/miqcli/collections/results.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Results collections."""
 
     @client_api

--- a/miqcli/collections/roles.py
+++ b/miqcli/collections/roles.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Roles collections."""
 
     @client_api

--- a/miqcli/collections/security_groups.py
+++ b/miqcli/collections/security_groups.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Security groups collections."""
 
     @client_api

--- a/miqcli/collections/servers.py
+++ b/miqcli/collections/servers.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Servers collections."""

--- a/miqcli/collections/service_catalogs.py
+++ b/miqcli/collections/service_catalogs.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Service catalogs collections."""
 
     @client_api

--- a/miqcli/collections/service_orders.py
+++ b/miqcli/collections/service_orders.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Service orders collections."""
 
     @client_api

--- a/miqcli/collections/service_requests.py
+++ b/miqcli/collections/service_requests.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Service requests collections."""
 
     @client_api

--- a/miqcli/collections/service_templates.py
+++ b/miqcli/collections/service_templates.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Service templates collections."""
 
     @client_api

--- a/miqcli/collections/services.py
+++ b/miqcli/collections/services.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Services collections."""
 
     @client_api

--- a/miqcli/collections/settings.py
+++ b/miqcli/collections/settings.py
@@ -14,6 +14,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 
-class Collections(object):
+
+class Collections(CollectionsMixin):
     """Settings collections."""

--- a/miqcli/collections/tags.py
+++ b/miqcli/collections/tags.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Tags collections."""
 
     @client_api

--- a/miqcli/collections/tasks.py
+++ b/miqcli/collections/tasks.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Tasks collections."""
 
     @client_api

--- a/miqcli/collections/templates.py
+++ b/miqcli/collections/templates.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Templates collections."""
 
     @client_api

--- a/miqcli/collections/tenants.py
+++ b/miqcli/collections/tenants.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Tenants collections."""
 
     @client_api

--- a/miqcli/collections/users.py
+++ b/miqcli/collections/users.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Users collections."""
 
     @client_api

--- a/miqcli/collections/virtual_templates.py
+++ b/miqcli/collections/virtual_templates.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Virtual templates collections."""
 
     @client_api

--- a/miqcli/collections/vms.py
+++ b/miqcli/collections/vms.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Virtual machines collections."""
 
     @client_api

--- a/miqcli/collections/zones.py
+++ b/miqcli/collections/zones.py
@@ -14,10 +14,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from miqcli.collections import CollectionsMixin
 from miqcli.decorators import client_api
 
 
-class Collections(object):
+class Collections(CollectionsMixin):
     """Zones collections."""
 
     @client_api


### PR DESCRIPTION
The actions return data is created using Python's built-in map. Map
return data type changed from Python 2/3. This commit will maintain
the client compatibility to handle getting the request id from the
actions return data.

All collections now have a req_id property. Set this property when
saving the collection action return data. This property will handle
getting the request id independent on the Python version the client is
using.

Closes #93 

This patch to resolve the bug is a small code change. It looks like a lot of changes in the collection modules  because I needed to have each class inherit the mixin class. With this mixin class, we can easily inject useful properties, attributes, etc into each collection class.