### PR TITLE
fix loading config when config file is invalid

### DIFF
--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -84,7 +84,7 @@ class Config(dict):
                         self[key] = value
         except yaml.YAMLError as e:
             if self._verbose:
-                log.debug('Standard error: {0}'.format(e.sterror))
+                log.debug('Standard error: {0}'.format(e))
             log.abort('Error in config {0}.'.format(_cfg_file))
 
     def from_env(self, var):

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -73,11 +73,15 @@ class Config(dict):
         try:
             with open(_cfg_file, mode='rb') as fp:
                 config_data = yaml.load(fp)
-                if config_data is not None:
+
+                if isinstance(config_data, str):
+                    log.abort('Config file {0} formatted incorrectly.'.format(
+                        _cfg_file))
+                elif config_data is None:
+                    log.warning('Config file {0} is empty.'.format(_cfg_file))
+                else:
                     for key, value in config_data.items():
                         self[key] = value
-                else:
-                    log.warning('Config file {0} is empty.'.format(_cfg_file))
         except yaml.YAMLError as e:
             if self._verbose:
                 log.debug('Standard error: {0}'.format(e.sterror))


### PR DESCRIPTION
This commit will add an extra layer of protection when trying to parse
a config file that has invalid data. An AttributeError was seen when
trying to get key:value entries from a config file in the form of a
string data type. A check is put in place to quit the client if the
config file content is in string format. Config file format should be
in the form of a dictionary data type.

Fixes #92 

I spoke with @vi-patel asking if he could provide his example config file causing the bug and he may have overwrote the file he said. I believe this check (added in the PR) in place should resolve most of the potential errors that could happen when trying to parse the config file content. Along with the additional checks for checking if the file is empty or handling yaml exceptions thrown when trying to load the file using the yaml module.