### PR TITLE
catch syntax error when loading config from environment

### DIFF
--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -99,6 +99,9 @@ class Config(dict):
         except KeyError:
             if self._verbose:
                 log.warning('Config environment variable is undefined.')
+        except SyntaxError:
+            log.abort('The syntax of the environment variable content '
+                      'is not valid. Check its content.')
 
 
 def get_class_methods(cls):


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

The function `ast.literal_eval` will throw a SyntaxError exception
in case the given parameter is not part of its acceptable formats
list.

In this case, like loading from yaml, we want the CLI to fail
because there's an intention of the user to use environment
variable but the content is not correctly formatted.

## Does this close any currently open issues?

No issue opened for this PR.
