### PR TITLE
fix vms collections delete command message formatting

### DIFF
--- a/miqcli/collections/vms.py
+++ b/miqcli/collections/vms.py
@@ -123,9 +123,11 @@ class Collections(CollectionsMixin):
     @click.argument('vm_name', metavar='VM_NAME', type=str, default='')
     @client_api
     def delete(self, vm_name):
-        """Delete
+        """Delete.
 
+        ::
         :param vm_name: name of the vm
+        :type vm_name: str
         :return: id of a task that will delete the vm
         :rtype: int
         """


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR fixes the `vms` collections `delete` command help message formatting. At the moment, the help message is displaying the documented parameters the command accepts. These should not be displayed in the help message for the command.

## Does this close any currently open issues?

It does not close any open issues.

## More comments

Current help message:
```bash
(miq-py36) [rywillia@laptop ~]$ miqcli vms --help
Usage: miqcli vms [OPTIONS] COMMAND [ARGS]...

  Virtual machines collections.

Options:
  --help  Show this message and exit.

Commands:
  add_event            Add event.
  add_lifecycle_event  Add lifecycle event.
  assign_tags          Assign tags.
  delete               Delete :param vm_name: name of the vm :type...
  edit                 Edit.
  pause                Pause.
  query                Query.
  reboot_guest         Reboot guest.
  refresh              Refresh.
  request_console      Request console.
  reset                Reset.
  retire               Retire.
  scan                 Scan.
  set_owner            Set owner.
  set_ownership        Set ownership.
  shelve               Shelve.
  shelve_offload       Shelve offload.
  shutdown_guest       Shutdown guest.
  start                Start.
  stop                 Stop.
  suspend              Suspend.
  unassign_tags        Unassign tags.
```
The help message should be formatted as such:

```bash
(miq-py36) [rywillia@laptop ~]$ miqcli vms --help
Usage: miqcli vms [OPTIONS] COMMAND [ARGS]...

  Virtual machines collections.

Options:
  --help  Show this message and exit.

Commands:
  add_event            Add event.
  add_lifecycle_event  Add lifecycle event.
  assign_tags          Assign tags.
  delete               Delete.
  edit                 Edit.
  pause                Pause.
  query                Query.
  reboot_guest         Reboot guest.
  refresh              Refresh.
  request_console      Request console.
  reset                Reset.
  retire               Retire.
  scan                 Scan.
  set_owner            Set owner.
  set_ownership        Set ownership.
  shelve               Shelve.
  shelve_offload       Shelve offload.
  shutdown_guest       Shutdown guest.
  start                Start.
  stop                 Stop.
  suspend              Suspend.
  unassign_tags        Unassign tags.
```