### PR TITLE
enable codecov for easy viewing code coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ matrix:
     - python: 3.6
       env: TOXENV=py36,pep8,docs
 install:
+  - pip install codecov
   - pip install tox
   - pip install -r test-requirements.txt
 script:
   - tox
+after_success:
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 A ManageIQ Command-Line Client
 ==============================
 
-|docs-badge| |build-badge|
+|docs-badge| |build-badge| |coverage-badge|
 
 Documentation
 -------------
@@ -22,3 +22,8 @@ The latest documentation is available on
     :alt: Build Status
     :scale: 100%
     :target: https://travis-ci.org/rhpit/manageiq-cli
+
+.. |coverage-badge| image:: https://codecov.io/gh/rhpit/manageiq-cli/branch/master/graph/badge.svg
+    :alt: Code Coverage Status
+    :scale: 100%
+    :target: https://codecov.io/gh/rhpit/manageiq-cli


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR enables `codecov` for the project. Codecov will provide coverage reports for each PR opened. Each coverage report will show which lines are covered and which are not. It also provides the ability to comment on PR providing a quick coverage recap for the reviewers.

## Does this close any currently open issues?

It does not close any open issues.

## More comments

Coverage reports can be found at the following: https://codecov.io/gh/rhpit/manageiq-cli
