### PR TITLE
Adding support for multiple attributes for instance query

### DIFF
--- a/example/osp_deletion_example.py
+++ b/example/osp_deletion_example.py
@@ -37,7 +37,7 @@ fip_id = None
 client.collection = "instances"
 try:
     instances = client.collection.query(inst_name=INPUT,
-                                        attr="floating_ip")
+                                        attr=('floating_ip',))
     fip_id = instances["floating_ip"]["id"]
 except SystemExit as e:
     print('No associated floating ips for instance: {0}, will continue to'

--- a/example/osp_provision_example.py
+++ b/example/osp_provision_example.py
@@ -98,10 +98,13 @@ print("State: {0} and Status: {1}".format(req_state, req_status))
 
 vm_name = payload_data["vm_name"]
 # 7. Report the floating ip address back to the user
+# need an extra sleep to make sure floating ip is added to
+# the instance after provisioning
+sleep(10)
 try:
     client.collection = "instances"
     instances = client.collection.query(inst_name=vm_name,
-                                        attr="floating_ip")
+                                        attr=("floating_ip",))
     fip = instances["floating_ip"]["address"]
     print("Floating ip for {0}: {1}".format(vm_name, fip))
 except SystemExit as e:

--- a/miqcli/collections/instances.py
+++ b/miqcli/collections/instances.py
@@ -38,7 +38,7 @@ class Collections(CollectionsMixin):
         :param inst_name: name of the instance
         :type inst_name: str
         :param attr: attribute
-        :type attr: str
+        :type attr: tuple
         :return: instance object or list of instance objects
         """
 
@@ -126,6 +126,8 @@ class Collections(CollectionsMixin):
     @client_api
     def terminate(self, inst_name):
         """Terminate instance.
+
+        ::
 
         :param inst_name: name of the instance
         :type inst_name: str


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
Adding support to query for multiple attributes:
miqcli --verbose instances query --attr hardware --attr floating_ip --attr active

Previously, you could only pass a single attribute, but there may be cases where it would be beneficial to see more attributes.

api call updated:

previously, attr was a str
client.collection.query(inst_name="<vm_name>", attr="floating_ip")

updated to now be a tuple:
client.collection.query(inst_name="<vm_name>", attr=("floating_ip",))

 * update requires update to the example scripts
 * while working on the update, fixed an issue w/ displaying all instances w/attributes set (header was previously set for each instance instead of being displayed once).


## Does this close any currently open issues?
no, this is an enhancement