### PR TITLE
catch connection error when checking if token is valid

### DIFF
--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -178,11 +178,15 @@ class ClientAPI(object):
         :return: True if token is valid otherwise False
         """
         headers = {'Accept': 'application/json', 'X-Auth-Token': token}
-        output = requests.get(self._url, headers=headers,
-                              verify=self._verify_ssl)
-        if output.status_code != 200:
-            return False
-        return True
+        try:
+            output = requests.get(self._url, headers=headers,
+                                  verify=self._verify_ssl)
+            if output.status_code != 200:
+                return False
+            return True
+        except ConnectionError:
+            log.abort('Error connecting to service. Check your connection '
+                      'settings.')
 
     def _generate_token(self):
         """


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR resolves a connection error from being raised when attempting to validate an existing token. This exception is thrown when no active manageiq services are running. Handling the exception removes the exception being logged to console and exits the client with the correct return code.

## Does this close any currently open issues?

Closes #115 


