### PR TITLE
add ability to add and delete providers

### DIFF
--- a/example/providers/amazon/create.py
+++ b/example/providers/amazon/create.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to add Amazon provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Set the required environment variables
+        - AWS_REGION
+        - AWS_ZONE
+        - AWS_USERNAME
+        - AWS_PASSWORD
+    3. Run script
+        - $ python ./create.py
+"""
+
+import os
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+REGION = os.getenv('AWS_REGION')
+ZONE = os.getenv('AWS_ZONE')
+USERNAME = os.getenv('AWS_USERNAME')
+PASSWORD = os.getenv('AWS_PASSWORD')
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.create(
+        'Amazon',
+        region=REGION,
+        zone=ZONE,
+        username=USERNAME,
+        password=PASSWORD
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/example/providers/amazon/delete.py
+++ b/example/providers/amazon/delete.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to delete Amazon provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Run script
+        - $ python ./delete.py
+"""
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.delete('Amazon')
+
+
+if __name__ == '__main__':
+    main()

--- a/example/providers/amazon/refresh.py
+++ b/example/providers/amazon/refresh.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to refresh Amazon provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Run script
+        - $ python ./refresh.py
+"""
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.refresh('Amazon')
+
+
+if __name__ == '__main__':
+    main()

--- a/example/providers/openstack/create.py
+++ b/example/providers/openstack/create.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to add OpenStack provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Set the required environment variables
+        - OSP_HOSTNAME
+        - OSP_PORT
+        - OSP_USERNAME
+        - OSP_PASSWORD
+    3. Run script
+        - $ python ./create.py
+"""
+
+import os
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+HOSTNAME = os.getenv('OSP_HOSTNAME')
+PORT = os.getenv('OSP_PORT')
+USERNAME = os.getenv('OSP_USERNAME')
+PASSWORD = os.getenv('OSP_PASSWORD')
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.create(
+        'OpenStack',
+        hostname=HOSTNAME,
+        port=PORT,
+        username=USERNAME,
+        password=PASSWORD
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/example/providers/openstack/delete.py
+++ b/example/providers/openstack/delete.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to delete OpenStack provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Run script
+        - $ python ./delete.py
+"""
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.delete('OpenStack')
+
+
+if __name__ == '__main__':
+    main()

--- a/example/providers/openstack/refresh.py
+++ b/example/providers/openstack/refresh.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Demo script used to refresh OpenStack provider.
+
+How to run:
+    1. Install manageiq-cli
+        - $ pip install -e .
+    2. Run script
+        - $ python ./refresh.py
+"""
+
+from miqcli import Client
+from miqcli.constants import DEFAULT_CONFIG
+
+
+def main():
+    client = Client(DEFAULT_CONFIG)
+    client.collection = 'providers'
+
+    client.collection.refresh('OpenStack')
+
+
+if __name__ == '__main__':
+    main()

--- a/miqcli/collections/providers.py
+++ b/miqcli/collections/providers.py
@@ -14,8 +14,61 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from pprint import pformat
+
+import click
+from collections import Mapping
+from manageiq_client.api import APIException
+
 from miqcli.collections import CollectionsMixin
+from miqcli.constants import SUPPORTED_PROVIDERS
 from miqcli.decorators import client_api
+from miqcli.provider import Provider
+from miqcli.query import BasicQuery
+from miqcli.utils import log
+
+
+class ProviderTypes(Mapping):
+    """Provider types.
+
+    Class used for mapping ManageIQ provider class names. These are static
+    names and at this time we are unable to retrieve these by REST API
+    providers collection. Providers collection only shows providers and their
+    type when added.
+    """
+
+    def __init__(self):
+        """Constructor.
+
+        The bulk of the work is here, this is where we will define the
+        matrix mapping provider name to its ManageIQ provider class.
+        """
+        self.__dict__.update(
+            amazon='ManageIQ::Providers::Amazon::CloudManager',
+            openstack='ManageIQ::Providers::Openstack::CloudManager'
+        )
+
+    def __getitem__(self, item):
+        """Get the provided keys value.
+
+        :param item: key name
+        :return: key value
+        """
+        return self.__dict__[item.lower()]
+
+    def __iter__(self):
+        """Returns a new iterator object based on the provider matrix.
+
+        :return: iterator object
+        """
+        return iter(self.__dict__)
+
+    def __len__(self):
+        """Returns the length of the provider matrix
+
+        :return: total number of provider types in the matrix
+        """
+        return len(self.__dict__)
 
 
 class Collections(CollectionsMixin):
@@ -23,25 +76,179 @@ class Collections(CollectionsMixin):
 
     @client_api
     def query(self):
-        """Query."""
+        """Query.
+
+        ::
+        Query  a provider in manageiq.
+        """
         raise NotImplementedError
 
+    @staticmethod
+    def _provider_exist(name, api):
+        """Determine whether the provider exists.
+
+        :param name: provider name
+        :param api: client api pointer
+        """
+        provider = Provider(name, api)
+        if provider.cloud_type:
+            log.debug('Provider: %s exists in manageiq.' % name)
+            found = True
+        else:
+            log.debug('Provider: %s does not exist in manageiq.' % name)
+            found = False
+        return found
+
+    @click.argument('name', type=click.Choice(SUPPORTED_PROVIDERS))
+    @click.option('--hostname', type=str, help='provider hostname/IP address.')
+    @click.option('--port', type=str, help='provider API port.')
+    @click.option('--region', type=str, help='provider region.')
+    @click.option('--zone', type=str, help='manageiq zone for the provider.')
+    @click.option('--username', type=str, help='provider username.',
+                  required=True)
+    @click.option('--password', type=str, help='provider password.',
+                  required=True)
     @client_api
-    def create(self):
-        """Create."""
-        raise NotImplementedError
+    def create(self, name, hostname=None, port=None, region=None, zone=None,
+               username=None, password=None):
+        """Create.
+
+        ::
+        Create a new provider in manageiq.
+
+        :param name: provider name
+        :param hostname: provider server hostname
+        :param port: provider port
+        :param region: provider region
+        :param zone: manageiq zone
+        :param username: provider username
+        :param password: provider password
+        :return: request id
+        """
+        _api = getattr(self, 'api')
+
+        if self._provider_exist(name, _api):
+            log.abort('Unable to process request to create provider: %s. '
+                      'The provider already exists.' % name)
+
+        log.info('Create provider: %s.' % name)
+
+        # okay good to go, lets create the payload
+        _payload = dict(
+            name=name,
+            type=ProviderTypes().get(name),
+            provider_region=region,
+            hostname=hostname,
+            port=port,
+            zone=zone,
+            credentials=[
+                dict(
+                    userid=username,
+                    password=password
+                )
+            ]
+        )
+
+        # zone requires href destination over string type
+        if zone:
+            query = BasicQuery(getattr(_api.client.collections, 'zones'))
+            query(('name', '=', zone))
+
+            if query.resources:
+                # RFE: remove using static position in list
+                _payload.update(dict(zone=dict(
+                    href=getattr(query.resources[0], '_href').replace(
+                        'zones', 'zone'))))
+
+        log.debug('Payload:\n %s' % pformat(_payload))
+
+        try:
+            self.req_id = getattr(self, 'action')(_payload)
+            log.info('Successfully submitted request to create provider: %s.'
+                     % name)
+            log.info('Create provider request ID: %s.' % self.req_id)
+            return self.req_id
+        except APIException as ex:
+            log.abort('Request to create provider: %s failed!\n Error: %s' %
+                      (name, ex))
 
     @client_api
     def edit(self):
-        """Edit."""
+        """Edit.
+
+        ::
+        Edit an existing provider in manageiq.
+        """
         raise NotImplementedError
 
+    @click.argument('name', type=click.Choice(SUPPORTED_PROVIDERS))
     @client_api
-    def refresh(self):
-        """Refresh."""
-        raise NotImplementedError
+    def refresh(self, name):
+        """Refresh.
 
+        ::
+        Refresh an existing provider in manageiq.
+
+        :param name: provider name
+        :return: request id
+        """
+        _api = getattr(self, 'api')
+
+        # quit if provider given does not exists in manageiq
+        if not self._provider_exist(name, _api):
+            log.abort('Unable to process request to refresh provider: %s. '
+                      'The provider does not exist in manageiq.' % name)
+
+        # get the provider id
+        query = BasicQuery(getattr(_api.client.collections, 'providers'))
+        query(('name', '=', name))
+
+        # okay good to go, lets create the payload
+        # RFE: multiple resources? this only gives first index in list
+        _payload = dict(id=query.resources.pop()['id'])
+
+        log.debug('Payload:\n %s' % pformat(_payload))
+
+        try:
+            self.req_id = getattr(self, 'action')(_payload)
+            log.info('Successfully submitted request to refresh provider: %s.'
+                     '\nRequest ID: %s.' % (name, self.req_id))
+            return self.req_id
+        except APIException as ex:
+            log.abort('Request to refresh provider: %s failed!\n Error: %s' %
+                      (name, ex))
+
+    @click.argument('name', type=click.Choice(SUPPORTED_PROVIDERS))
     @client_api
-    def delete(self):
-        """Delete."""
-        raise NotImplementedError
+    def delete(self, name):
+        """Delete.
+
+        ::
+        Delete an existing provider in manageiq.
+
+        :param name: provider name
+        :return: request id
+        """
+        _api = getattr(self, 'api')
+
+        if not self._provider_exist(name, _api):
+            log.abort('Unable to process request to delete provider: %s. '
+                      'The provider does not exist.' % name)
+
+        # get the provider id
+        query = BasicQuery(getattr(_api.client.collections, 'providers'))
+        query(('name', '=', name))
+
+        # okay good to go, lets create the payload
+        _payload = dict(id=query.resources.pop()['id'])
+
+        log.debug('Payload:\n %s' % pformat(_payload))
+
+        try:
+            self.req_id = getattr(self, 'action')(_payload)
+            log.info('Successfully submitted request to delete provider: %s.\n'
+                     'Request ID: %s.' % (name, self.req_id))
+            return self.req_id
+        except APIException as ex:
+            log.abort('Request to delete provider: %s failed!\n Error: %s' %
+                      (name, ex))

--- a/miqcli/constants.py
+++ b/miqcli/constants.py
@@ -77,7 +77,7 @@ for name in vars(AR):
         all_ar_requests.append(name)
 
 SUPPORTED_AUTOMATE_REQUESTS = all_ar_requests
-SUPPORTED_PROVIDERS = ["OpenStack", "Amazon"]
+SUPPORTED_PROVIDERS = ["Amazon", "OpenStack"]
 REQUIRED_OSP_KEYS = ["email", "tenant", "image", "network",
                      "flavor", "vm_name"]
 OPTIONAL_OSP_KEYS = ["fip_pool", "security_group", "key_pair"]

--- a/miqcli/provider.py
+++ b/miqcli/provider.py
@@ -19,8 +19,8 @@ from manageiq_client.api import APIException
 from miqcli.query import AdvancedQuery
 from miqcli.utils import log
 
-__all__ = ['Flavors', 'Templates', 'SecurityGroups', 'KeyPair', 'Tenant',
-           'Networks', 'Instances', 'Vms']
+__all__ = ['Provider', 'Flavors', 'Templates', 'SecurityGroups', 'KeyPair',
+           'Tenant', 'Networks', 'Instances', 'Vms']
 
 
 class Provider(object):

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -119,7 +119,7 @@ def get_class_methods(cls):
     for key, value in cls.__dict__.items():
         if not isinstance(value, FunctionType):
             continue
-        if key == "__init__":
+        if key.startswith('_'):
             continue
         methods.append(key)
     methods.sort()


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR provides the client with the functionality to add, delete and refresh providers in manageiq. This PR currently only supports the following providers: `amazon|openstack`.

## Does this close any currently open issues?

Closes #15 

## More comments

For examples on how you can use the client to add, delete or refresh providers, please see `examples/providers/<provider>/<script>.py`. Each script has a doc string explaining how to run the script. You can also add, delete or refresh providers as the following: `$ miqcli providers <action> <options> etc..`.
