### PR TITLE
give CLI ability to see the details of an automation request

### DIFF
--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -17,6 +17,7 @@
 import click
 from collections import OrderedDict
 from manageiq_client.api import APIException
+from pprint import pformat
 
 from miqcli.collections import CollectionsMixin
 from miqcli.constants import OSP_FIP_PAYLOAD, SUPPORTED_AUTOMATE_REQUESTS, AR
@@ -146,7 +147,7 @@ class Collections(CollectionsMixin):
             for key, value in status.items():
                 log.info(' * %s: %s' % (key.upper(), value))
             # if verbosity is set, get more info about the request
-            log.debug(req.options)
+            log.debug('\n' + pformat(req.options, indent=4))
             log.info('-' * 50)
 
             return req

--- a/miqcli/collections/automation_requests.py
+++ b/miqcli/collections/automation_requests.py
@@ -145,6 +145,8 @@ class Collections(CollectionsMixin):
             log.info(' * ID: %s' % req_id)
             for key, value in status.items():
                 log.info(' * %s: %s' % (key.upper(), value))
+            # if verbosity is set, get more info about the request
+            log.debug(req.options)
             log.info('-' * 50)
 
             return req


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
Adding the ability to get the details of an automation request.

## Does this close any currently open issues?
Closes #133 

## More comments
To get the details of an automation request, the user just needs to have --verbose option set to true:
Example:
$ miqcli --verbose automation_requests status 140
INFO: --------------------------------------------------
INFO: Automation request
INFO: --------------------------------------------------
INFO: * ID: 140
INFO: * STATE: finished
INFO: * STATUS: Ok
INFO: * MESSAGE: Automation Request completed
DEBUG:
DEBUG: 
{   u'attrs': {   u'cloud_network_id': 2,
                  u'cloud_tenant_id': 1,
                  u'userid': u'admin'},
    u'class_name': u'Methods',
    u'delivered_on': u'2018-03-12T12:27:22.667Z',
    u'instance_name': u'get_floating_ip',
    u'namespace': u'CF_MIQ_CLI/General',
    u'return': u'{"status":"success","return":{"<ip_address>":<ip_address_id>}}',
    u'user_id': 1}

If a user just wants basic details, they do not need to add the verbose option:
$ miqcli automation_requests status 140
WARNING: Default configuration is used.
INFO: --------------------------------------------------
INFO: Automation request
INFO: --------------------------------------------------
INFO: * ID: 140
INFO: * STATE: finished
INFO: * STATUS: Ok
INFO: * MESSAGE: Automation Request completed
INFO: --------------------------------------------------
