### PR TITLE
add warning if etc config directory does not exist

### DIFF
--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -56,6 +56,12 @@ class Config(dict):
         """
         _cfg_file = None
 
+        # verify directory is defined
+        if not os.path.isdir(directory):
+            if self._verbose:
+                log.warning('Directory {0} is undefined.'.format(directory))
+            return
+
         # verify config file exists
         for entry in os.listdir(directory):
             _file = os.path.splitext(entry)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
Currently, if the `/etc/miqcli` does not exist, an error occurs
and the client stops.

As per earlier decision, we do not want the client to fail if
the main configuration directory does not exist, but carry on
looking for more precedent configurations or use the default
pre-baked into the project.

This commit fixes this by throwing a warning message that the
directory does not exist and keep the client running as expected.