### PR TITLE
remove static code blocks for creating and deleting providers

### DIFF
--- a/doc/source/providers/amazon.rst
+++ b/doc/source/providers/amazon.rst
@@ -55,24 +55,11 @@ Python Code
 +++++++++++
 
 This code example will demonstrate how you can use the client in a Python
-module to create a new provider. Before running the Python code, replace the
-**<value>** with your Amazon authentication details.
+module to create a new provider.
 
-.. code-block:: python
+.. literalinclude:: ../../../example/providers/amazon/create.py
     :linenos:
-
-    from miqcli import Client
-    from miqcli.constants import DEFAULT_CONFIG
-
-    client = Client(DEFAULT_CONFIG)
-    client.collection = 'providers'
-
-    client.collection.create(
-        'Amazon',
-        region=<region>,
-        username=<username>,
-        password=<password>
-    )
+    :lines: 32-
 
 On completion, you should receive an ID for your transaction.
 
@@ -128,16 +115,9 @@ Python Code
 This code example will demonstrate how you can use the client in a Python
 module to delete a provider.
 
-.. code-block:: python
+.. literalinclude:: ../../../example/providers/amazon/delete.py
     :linenos:
-
-    from miqcli import Client
-    from miqcli.constants import DEFAULT_CONFIG
-
-    client = Client(DEFAULT_CONFIG)
-    client.collection = 'providers'
-
-    client.collection.delete('Amazon')
+    :lines: 27-
 
 On completion, you should receive an ID for your transaction.
 

--- a/doc/source/providers/openstack.rst
+++ b/doc/source/providers/openstack.rst
@@ -56,25 +56,11 @@ Python Code
 +++++++++++
 
 This code example will demonstrate how you can use the client in a Python
-module to create a new provider. Before running the Python code, replace the
-**<value>** with your OpenStack authentication details.
+module to create a new provider.
 
-.. code-block:: python
+.. literalinclude:: ../../../example/providers/openstack/create.py
     :linenos:
-
-    from miqcli import Client
-    from miqcli.constants import DEFAULT_CONFIG
-
-    client = Client(DEFAULT_CONFIG)
-    client.collection = 'providers'
-
-    client.collection.create(
-        'OpenStack',
-        hostname=<hostname>,
-        port=<port>,
-        username=<username>,
-        password=<password>
-    )
+    :lines: 32-
 
 On completion, you should receive an ID for your transaction.
 
@@ -129,16 +115,9 @@ Python Code
 This code example will demonstrate how you can use the client in a Python
 module to delete a provider.
 
-.. code-block:: python
+.. literalinclude:: ../../../example/providers/openstack/delete.py
     :linenos:
-
-    from miqcli import Client
-    from miqcli.constants import DEFAULT_CONFIG
-
-    client = Client(DEFAULT_CONFIG)
-    client.collection = 'providers'
-
-    client.collection.delete('OpenStack')
+    :lines: 27-
 
 On completion, you should receive an ID for your transaction.
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

Removes static code blocks for Python examples for creating and deleting providers. They were a duplicate copy of the ones under the miqcli/examples directory. Updated provider files to use sphinx `literalinclude` to include the Python code snippet examples.

## Does this close any currently open issues?

No issues are related to this PR.