### PR TITLE
update client class loading server configuration

### DIFF
--- a/example/aws_deletion_example.py
+++ b/example/aws_deletion_example.py
@@ -15,7 +15,6 @@
 #
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 from time import sleep
 
 # The input to aws deletion is the name of the vm and provider name
@@ -32,7 +31,7 @@ INPUT_PROVIDER_NAME = None
 INPUT_NETWORK = None
 INPUT_SUBNET = None
 
-client = Client(DEFAULT_CONFIG)
+client = Client()
 
 # 1. Query the instance to obtain ID
 client.collection = "instances"

--- a/example/aws_provision_example.py
+++ b/example/aws_provision_example.py
@@ -15,13 +15,12 @@
 #
 
 import json
-from miqcli.constants import DEFAULT_CONFIG
 from miqcli import Client
 from time import sleep
 
 # create a client object
 # use the default credentials
-client = Client(DEFAULT_CONFIG)
+client = Client()
 
 # 1. Gather the input payload data
 # Uncomment desired example

--- a/example/osp_deletion_example.py
+++ b/example/osp_deletion_example.py
@@ -32,15 +32,7 @@ INPUT_SUBNET = None
 
 
 # create a client object
-# pass in config, if empty {} means it will use the default credentials
-config = {
-    'username': 'admin',
-    'password': 'smartvm',
-    'url': 'https://localhost:8443',
-    'enable_ssl_verify': False
-}
-
-client = Client(config)
+client = Client()
 fip_id = None
 
 # 1. Query the instance to delete to see if the instance has a floating ip

--- a/example/osp_provision_example.py
+++ b/example/osp_provision_example.py
@@ -20,15 +20,7 @@ import json
 from time import sleep
 
 # create a client object
-# pass in config, if empty {} means it will use the default credentials
-config = {
-    'username': 'admin',
-    'password': 'smartvm',
-    'url': 'https://localhost:8443',
-    'enable_ssl_verify': False
-}
-
-client = Client(config)
+client = Client()
 
 # 1. Gather the input payload data
 payload_file = "openstack_provision_ex.json"

--- a/example/providers/amazon/create.py
+++ b/example/providers/amazon/create.py
@@ -32,7 +32,6 @@ How to run:
 import os
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 REGION = os.getenv('AWS_REGION')
 ZONE = os.getenv('AWS_ZONE')
@@ -41,7 +40,7 @@ PASSWORD = os.getenv('AWS_PASSWORD')
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.create(

--- a/example/providers/amazon/delete.py
+++ b/example/providers/amazon/delete.py
@@ -25,11 +25,10 @@ How to run:
 """
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.delete('Amazon')

--- a/example/providers/amazon/refresh.py
+++ b/example/providers/amazon/refresh.py
@@ -25,11 +25,10 @@ How to run:
 """
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.refresh('Amazon')

--- a/example/providers/openstack/create.py
+++ b/example/providers/openstack/create.py
@@ -32,7 +32,6 @@ How to run:
 import os
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 HOSTNAME = os.getenv('OSP_HOSTNAME')
 PORT = os.getenv('OSP_PORT')
@@ -41,7 +40,7 @@ PASSWORD = os.getenv('OSP_PASSWORD')
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.create(

--- a/example/providers/openstack/delete.py
+++ b/example/providers/openstack/delete.py
@@ -25,11 +25,10 @@ How to run:
 """
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.delete('OpenStack')

--- a/example/providers/openstack/refresh.py
+++ b/example/providers/openstack/refresh.py
@@ -25,11 +25,10 @@ How to run:
 """
 
 from miqcli import Client
-from miqcli.constants import DEFAULT_CONFIG
 
 
 def main():
-    client = Client(DEFAULT_CONFIG)
+    client = Client()
     client.collection = 'providers'
 
     client.collection.refresh('OpenStack')

--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -277,7 +277,7 @@ class Client(object):
         """
 
         # lets first load the correct server configuration settings
-        config = Config(defaults=DEFAULT_CONFIG, verbose=verbose)
+        config = Config(settings=DEFAULT_CONFIG, verbose=verbose)
         if conf:
             config.update(conf)
         config.from_yml(CFG_DIR, CFG_NAME)

--- a/miqcli/api.py
+++ b/miqcli/api.py
@@ -28,8 +28,8 @@ from manageiq_client.api import APIException, ManageIQClient
 
 from requests.exceptions import ConnectionError
 
-from miqcli.constants import TOKENFILE, DEFAULT_CONFIG
-from miqcli.utils import log, get_collection_class
+from miqcli.constants import CFG_DIR, CFG_NAME, DEFAULT_CONFIG, TOKENFILE
+from miqcli.utils import log, get_collection_class, Config
 
 __all__ = ['ClientAPI', 'Client']
 
@@ -267,7 +267,7 @@ class Client(object):
 
     _collection = object
 
-    def __init__(self, conf, verbose=False):
+    def __init__(self, conf=None, verbose=False):
         """Constructor.
 
         :param conf: server configuration
@@ -276,8 +276,16 @@ class Client(object):
         :type verbose: bool
         """
 
+        # lets first load the correct server configuration settings
+        config = Config(defaults=DEFAULT_CONFIG, verbose=verbose)
+        if conf:
+            config.update(conf)
+        config.from_yml(CFG_DIR, CFG_NAME)
+        config.from_yml(os.path.join(os.getcwd()), CFG_NAME)
+        config.from_env('MIQ_CFG')
+
         # create client api instance
-        api = ClientAPI(conf)
+        api = ClientAPI(config)
         api.connect()
 
         # create click context object (req. for each collection class)

--- a/miqcli/utils/__init__.py
+++ b/miqcli/utils/__init__.py
@@ -35,15 +35,15 @@ __all__ = ['Config', 'get_class_methods', 'get_client_api_pointer',
 class Config(dict):
     """Configuration class."""
 
-    def __init__(self, defaults=None, verbose=False):
+    def __init__(self, settings=None, verbose=False):
         """Constructor.
 
-        :param defaults: base dictionary configuration
-        :type defaults: dict
+        :param settings: configuration settings
+        :type settings: dict
         :param verbose: verbosity mode
         :type verbose: bool
         """
-        super(Config, self).__init__(defaults or {})
+        super(Config, self).__init__(settings or {})
         self._verbose = verbose
 
     def from_yml(self, directory, filename):


### PR DESCRIPTION
## What does this implement/fix? Explain your changes

This PR updates the client class to have the same capabilities of
loading server configuration settings just like you can from the
command line. Previously it would only load server configuration
settings when instantiating the client class.

Updated example scripts to no longer need to define the default config
settings. These will be set by default.

## Does this close any currently open issues?

No open issues are related to this PR.