### PR TITLE
add integration test case to validate commands list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+integration27.xml
+integration36.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/tests/assets/integration_config.yml
+++ b/tests/assets/integration_config.yml
@@ -1,0 +1,5 @@
+---
+  url: https://localhost:8443
+  username: admin
+  password: smartvm
+  enable_ssl_verify: False

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,26 @@
+import os
+import stat
+import pkgutil
+
+import requests
+from unittest import TestCase
+from nose.tools import assert_equal
+
+class TestCollections(TestCase):
+    """Test Collections module"""
+
+    def setUp(self):
+
+        # I want a list of all valid collections from the appliance
+        r = requests.get('https://localhost:8443/api', auth=('admin', 'smartvm'), verify=False)
+        self.appliance_collections = set([c['name'] for c in r.json()['collections']])
+
+    def tearDown(self):
+        del(self.appliance_collections)
+
+    def test_collection_representation_from_appliances(self):
+        import miqcli.collections
+        colpath = os.path.dirname(miqcli.collections.__file__)
+        client_collections = set([name for _, name, _ in pkgutil.iter_modules([colpath])])
+        dif = client_collections.difference(self.appliance_collections)
+        assert_equal(len(dif), 0)

--- a/tests/integration/test_collections.py
+++ b/tests/integration/test_collections.py
@@ -13,14 +13,16 @@ class TestCollections(TestCase):
 
         # I want a list of all valid collections from the appliance
         r = requests.get('https://localhost:8443/api', auth=('admin', 'smartvm'), verify=False)
-        self.appliance_collections = set([c['name'] for c in r.json()['collections']])
+        self.appliance_collections = [c['name'] for c in r.json()['collections']]
 
     def tearDown(self):
         del(self.appliance_collections)
 
     def test_collection_representation_from_appliances(self):
+        # test if CLI collections matches appliance collections
         import miqcli.collections
         colpath = os.path.dirname(miqcli.collections.__file__)
-        client_collections = set([name for _, name, _ in pkgutil.iter_modules([colpath])])
-        dif = client_collections.difference(self.appliance_collections)
+        client_collections = [name for _, name, _ in pkgutil.iter_modules([colpath])]
+        assert_equal(len(client_collections), len(self.appliance_collections))
+        dif = [item for item in client_collections if item not in appliance_collections]
         assert_equal(len(dif), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,10 @@ commands = flake8 {posargs}
 [testenv:docs]
 commands = python setup.py build_sphinx
 
-[testenv:integration]
+[testenv:integration36]
 # this will run tests against a local instance of ManageIQ
+# TODO: remove the responsibility of tox to start/stop container, this is not working properly.
+basepython = python3.6
 whitelist_externals =
     bash
     sleep
@@ -51,11 +53,51 @@ deps =
     -r{toxinidir}/test-requirements.txt
     docker==2.1.0
 commands =
+    python --version
     {toxinidir}/scripts/testinstance -c start -n miqcli_testenv
-    sleep 40
-    phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/change_configuration.js
-    phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/install_datastore.js
-    nosetests --verbosity=2 --with-coverage --cover-erase --cover-html --cover-html-dir=cover/integration --cover-package=miqcli --tests=tests/integration
+    sleep 150
+    - phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/change_configuration.js
+    - phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/install_datastore.js
+    - nosetests --verbosity=2 \
+              --with-coverage \
+              --cover-erase \
+              --cover-html \
+              --cover-html-dir=cover/integration36 \
+              --cover-package=miqcli \
+              --with-xunit \
+              --xunit-file=integration36.xml \
+              --tests=tests/integration || {toxinidir}/scripts/testinstance -c stop -n miqcli_testenv
+    {toxinidir}/scripts/testinstance -c stop -n miqcli_testenv
+
+[testenv:integration27]
+# this will run tests against a local instance of ManageIQ
+# TODO: remove the responsibility of tox to start/stop container, this is not working properly.
+basepython = python2.7
+whitelist_externals =
+    bash
+    sleep
+    phantomjs
+setenv =
+    VIRTUAL_ENV={envdir}
+    CLIENT_NAME=miqcli
+deps =
+    -r{toxinidir}/test-requirements.txt
+    docker==2.1.0
+commands =
+    python --version
+    {toxinidir}/scripts/testinstance -c start -n miqcli_testenv
+    sleep 150
+    - phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/change_configuration.js
+    - phantomjs --config {toxinidir}/scripts/phantomjs-config.json {toxinidir}/scripts/install_datastore.js
+    - nosetests --verbosity=2 \
+              --with-coverage \
+              --cover-erase \
+              --cover-html \
+              --cover-html-dir=cover/integration27 \
+              --cover-package=miqcli \
+              --with-xunit \
+              --xunit-file=integration27.xml \
+              --tests=tests/integration
     {toxinidir}/scripts/testinstance -c stop -n miqcli_testenv
 
 [flake8]


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
This commit implements a test case for integration with ManageIQ appliances to ensure the list of the CLI collections match the list of the collections offered by the REST API.

The changes are applied only to the integration environment in the tox configuration. This test must run with a ManageIQ appliance running locally. A sequence of start, config, runtest and teardown is added to both environments (integration27 and integration36). This change is loose and easy to break if, for example, a docker container is already running with the same port exposed (8443) or if the container has the same name as defined in the tox file. Another thing that needs to be noted is that the nosetests command on both environment have a '-' set, which is a way to ignore the exit code. That way tox can always teardown the container (unless an unexpected error occurs).

Both environments produce coverage report and a xunit report that can be used by Jenkins. 

## Does this close any currently open issues?

Closes #29 


