### PR TITLE
update provision request data to also filter using the tenant id 

### DIFF
--- a/miqcli/collections/provision_requests.py
+++ b/miqcli/collections/provision_requests.py
@@ -84,6 +84,13 @@ class Collections(CollectionsMixin):
             OSP_PAYLOAD["requester"]["owner_email"] = input_data["email"]
             OSP_PAYLOAD["vm_fields"]["vm_name"] = input_data["vm_name"]
 
+            # lookup cloud tenant resource to get the id
+            tenant = Tenant(provider, self.api)
+            OSP_PAYLOAD['vm_fields']['cloud_tenant'] = tenant.get_id(
+                input_data['tenant']
+            )
+            tenant_id = OSP_PAYLOAD['vm_fields']['cloud_tenant']
+
             if 'floating_ip_id' in input_data:
                 OSP_PAYLOAD['vm_fields']['floating_ip_address'] = \
                     input_data['floating_ip_id']
@@ -103,7 +110,7 @@ class Collections(CollectionsMixin):
                 # lookup security group resource to get the id
                 sec_group = SecurityGroups(provider, self.api)
                 OSP_PAYLOAD['vm_fields']['security_groups'] = sec_group.get_id(
-                    input_data['security_group']
+                    input_data['security_group'], tenant_id
                 )
 
             if 'key_pair' in input_data and input_data["key_pair"]:
@@ -115,13 +122,7 @@ class Collections(CollectionsMixin):
             # lookup cloud network resource to get the id
             network = Networks(provider, self.api, 'private')
             OSP_PAYLOAD['vm_fields']['cloud_network'] = network.get_id(
-                input_data['network']
-            )
-
-            # lookup cloud tenant resource to get the id
-            tenant = Tenant(provider, self.api)
-            OSP_PAYLOAD['vm_fields']['cloud_tenant'] = tenant.get_id(
-                input_data['tenant']
+                input_data['network'], tenant_id
             )
 
             log.debug("Payload for the provisioning request: {0}".format(

--- a/miqcli/collections/vms.py
+++ b/miqcli/collections/vms.py
@@ -254,14 +254,16 @@ class Collections(CollectionsMixin):
         """Delete.
 
         ::
+        Delete the vm with the provided options.
+
         :param vm_name: name of the vm
         :type vm_name: str
         :param provider: name of the provider
         :type provider: str
         :param vendor: name of vendor
         :type vendor: str
-        :param itype: type of vm - "Openstack" or "Amazon"
-        :type itype: str
+        :param vtype: type of vm - "Openstack" or "Amazon"
+        :type vtype: str
         :param by_id: name is vm id
         :type by_id: bool
         :return: id of a task that will delete the vm

--- a/miqcli/provider.py
+++ b/miqcli/provider.py
@@ -155,7 +155,7 @@ class Provider(object):
                 self.__collection_name__, ent_id, e))
         return output
 
-    def get_resource(self, name):
+    def get_resource(self, name, tenant_id=None):
         """Get the resource based on the name given.
         :param name: resource name
         :type name: str
@@ -163,7 +163,11 @@ class Provider(object):
         :rtype: list
         """
         # advanced query
-        _query = [('name', '=', name), '&', ('type', '=', self.type)]
+        if tenant_id:
+            _query = [('name', '=', name), '&', ('type', '=', self.type), '&',
+                      ('cloud_tenant_id', '=', tenant_id)]
+        else:
+            _query = [('name', '=', name), '&', ('type', '=', self.type)]
 
         # tell query which collection to run the query against
         self.query.collection = self.collection
@@ -253,6 +257,11 @@ class SecurityGroups(Provider):
         self.collection = self.__collection_name__
         self.type = self.network_type + '::SecurityGroup'
 
+    def get_id(self, name, tenant_id):
+        """Override the parent get_id."""
+        self.get_resource(name, tenant_id)
+        return getattr(self.query, 'id')
+
 
 class KeyPair(Provider):
     """Provider key pair component."""
@@ -291,6 +300,11 @@ class Networks(Provider):
                 network.title()
         else:
             self.type = self.network_type + '::CloudNetwork'
+
+    def get_id(self, name, tenant_id=None):
+        """Override the parent get_id."""
+        self.get_resource(name, tenant_id)
+        return getattr(self.query, 'id')
 
 
 class Instances(Provider):

--- a/miqcli/provider.py
+++ b/miqcli/provider.py
@@ -159,6 +159,8 @@ class Provider(object):
         """Get the resource based on the name given.
         :param name: resource name
         :type name: str
+        :param tenant_id: optional tenant_id for querying
+        :type tenant_id: str
         :return: resources found from query
         :rtype: list
         """
@@ -258,7 +260,11 @@ class SecurityGroups(Provider):
         self.type = self.network_type + '::SecurityGroup'
 
     def get_id(self, name, tenant_id):
-        """Override the parent get_id."""
+        """Override the parent get_id.
+        :param name: resource name
+        :type name: str
+        :param tenant_id: tenant_id for querying
+        :type tenant_id: str"""
         self.get_resource(name, tenant_id)
         return getattr(self.query, 'id')
 
@@ -302,7 +308,11 @@ class Networks(Provider):
             self.type = self.network_type + '::CloudNetwork'
 
     def get_id(self, name, tenant_id=None):
-        """Override the parent get_id."""
+        """Override the parent get_id.
+        :param name: resource name
+        :type name: str
+        :param tenant_id: optional tenant_id for querying
+        :type tenant_id: str"""
         self.get_resource(name, tenant_id)
         return getattr(self.query, 'id')
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes
* updating provision requests querying to add filtering based on tenant id (cloud_networks public & security groups)
* doc fix for vm delete

## Does this close any currently open issues?
No.